### PR TITLE
fix(tests-e2e): register missing migrations in e2e harness

### DIFF
--- a/museum-backend/tests/helpers/e2e/e2e-app-harness.ts
+++ b/museum-backend/tests/helpers/e2e/e2e-app-harness.ts
@@ -101,6 +101,8 @@ export async function createE2EHarness(): Promise<E2EHarness> {
     { CreateKnowledgeExtractionTables1775852800000 },
     { AddUserContentPreferences1776276072750 },
     { AddAudioToChatMessage1776593841594 },
+    { Check1776593907869 },
+    { AddUserNotifyOnReviewModeration1776600000000 },
     { ChatService },
     { TypeOrmChatRepository },
     { LocalImageStorage },
@@ -141,6 +143,8 @@ export async function createE2EHarness(): Promise<E2EHarness> {
     import('@src/data/db/migrations/1775852800000-CreateKnowledgeExtractionTables'),
     import('@src/data/db/migrations/1776276072750-AddUserContentPreferences'),
     import('@src/data/db/migrations/1776593841594-AddAudioToChatMessage'),
+    import('@src/data/db/migrations/1776593907869-Check'),
+    import('@src/data/db/migrations/1776600000000-AddUserNotifyOnReviewModeration'),
     import('@modules/chat/useCase/chat.service'),
     import('@modules/chat/adapters/secondary/chat.repository.typeorm'),
     import('@modules/chat/adapters/secondary/image-storage.stub'),
@@ -185,6 +189,8 @@ export async function createE2EHarness(): Promise<E2EHarness> {
     CreateKnowledgeExtractionTables1775852800000,
     AddUserContentPreferences1776276072750,
     AddAudioToChatMessage1776593841594,
+    Check1776593907869,
+    AddUserNotifyOnReviewModeration1776600000000,
   ];
 
   await appDataSource.initialize();


### PR DESCRIPTION
## Summary
- E2E harness uses an explicit migration list (not a glob) — two migrations added after `1776593841594-AddAudioToChatMessage` were missing.
- Result on main after PR #139: every e2e that registers a user hit `500 INTERNAL_ERROR` because `users.notify_on_review_moderation` was never created in the testcontainer.
- Fix: add `Check1776593907869` and `AddUserNotifyOnReviewModeration1776600000000` to both the dynamic-import list and the DataSource migration list.

## Test plan
- [ ] CI backend `quality` green
- [ ] CI backend `e2e` green (the suite that failed on #139 merge)
- [ ] Re-run any downstream jobs impacted

Cherry-pick of 003c1ad3 from `feat/enterprise-grade-sprint` after PR #139 was auto-merged before the e2e job surfaced the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)