### PR TITLE
fix(auth): stabilize session, reshape login, Face ID prompt

### DIFF
--- a/museum-frontend/__tests__/context/AuthContext.test.tsx
+++ b/museum-frontend/__tests__/context/AuthContext.test.tsx
@@ -72,10 +72,12 @@ jest.mock('@/features/daily-art/application/logoutCleanup', () => ({
   clearDailyArtStorage: (...args: unknown[]) => mockClearDailyArtStorage(...args),
 }));
 
+const mockRunAuthRefresh = jest.fn();
 jest.mock('@/shared/infrastructure/httpClient', () => ({
   setAuthRefreshHandler: jest.fn(),
   setTokenProvider: jest.fn(),
   setUnauthorizedHandler: jest.fn(),
+  runAuthRefresh: (...args: unknown[]) => mockRunAuthRefresh(...args),
 }));
 
 const mockReportErrorCalls: unknown[][] = [];
@@ -129,9 +131,10 @@ describe('AuthProvider / useAuth', () => {
     mockIsAccessTokenExpired.mockReturnValue(true);
     mockLogoutApi.mockResolvedValue({});
     mockCompleteOnboarding.mockResolvedValue(undefined);
+    mockRunAuthRefresh.mockResolvedValue({ kind: 'transient' });
   });
 
-  it('bootstrap with cached valid access token skips refresh call', async () => {
+  it('bootstrap hydrates cached access token without calling refresh', async () => {
     mockGetRefreshToken.mockResolvedValue('valid-refresh');
     mockGetPersistedAccessToken.mockResolvedValue('cached-access');
     mockIsAccessTokenExpired.mockReturnValue(false);
@@ -147,11 +150,13 @@ describe('AuthProvider / useAuth', () => {
     expect(mockSetAccessToken).toHaveBeenCalledWith('cached-access');
   });
 
-  it('bootstrap with expired cached access token triggers refresh', async () => {
+  it('bootstrap hydrates expired cached access token without calling refresh (defers to interceptor)', async () => {
+    // Single-flight invariant: bootstrap MUST NOT call /auth/refresh because
+    // the response interceptor will refresh on the first 401, and any parallel
+    // refresh would race the rotation and log the user out.
     mockGetRefreshToken.mockResolvedValue('valid-refresh');
     mockGetPersistedAccessToken.mockResolvedValue('expired-access');
     mockIsAccessTokenExpired.mockReturnValue(true);
-    mockRefresh.mockResolvedValue(makeSession());
 
     const { result } = renderHook(() => useAuth(), { wrapper });
 
@@ -160,9 +165,25 @@ describe('AuthProvider / useAuth', () => {
     });
 
     expect(result.current.isAuthenticated).toBe(true);
-    expect(mockRefresh).toHaveBeenCalledWith('valid-refresh');
-    expect(mockSetPersistedAccessToken).toHaveBeenCalledWith('new-access');
-    expect(mockSetRefreshToken).toHaveBeenCalledWith('new-refresh');
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockSetAccessToken).toHaveBeenCalledWith('expired-access');
+  });
+
+  it('bootstrap without cached access still flips isAuthenticated when a refresh token is present', async () => {
+    // No access token in storage but a refresh token exists → mark as
+    // authenticated; the first authed request will produce 401 → interceptor
+    // refreshes via the single-flight coordinator.
+    mockGetRefreshToken.mockResolvedValue('valid-refresh');
+    mockGetPersistedAccessToken.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 
   it('bootstrap without refreshToken sets isAuthenticated=false', async () => {
@@ -176,56 +197,6 @@ describe('AuthProvider / useAuth', () => {
 
     expect(result.current.isAuthenticated).toBe(false);
     expect(mockClearAccessToken).toHaveBeenCalled();
-  });
-
-  it('bootstrap clears tokens on Unauthorized refresh error', async () => {
-    mockGetRefreshToken.mockResolvedValue('stale-refresh');
-    mockRefresh.mockRejectedValue(
-      createAppError({ kind: 'Unauthorized', message: 'Invalid refresh' }),
-    );
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.isAuthenticated).toBe(false);
-    expect(mockClearRefreshToken).toHaveBeenCalled();
-    expect(mockClearPersistedAccessToken).toHaveBeenCalled();
-  });
-
-  it('bootstrap keeps tokens and falls back to cached access on Network error', async () => {
-    mockGetRefreshToken.mockResolvedValue('good-refresh');
-    mockGetPersistedAccessToken.mockResolvedValue('stale-access');
-    mockIsAccessTokenExpired.mockReturnValue(true);
-    mockRefresh.mockRejectedValue(createAppError({ kind: 'Network', message: 'offline' }));
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.isAuthenticated).toBe(true);
-    expect(mockSetAccessToken).toHaveBeenCalledWith('stale-access');
-    expect(mockClearRefreshToken).not.toHaveBeenCalled();
-    expect(mockClearPersistedAccessToken).not.toHaveBeenCalled();
-  });
-
-  it('bootstrap on Network error without cached access stays unauthenticated but keeps refresh token', async () => {
-    mockGetRefreshToken.mockResolvedValue('good-refresh');
-    mockGetPersistedAccessToken.mockResolvedValue(null);
-    mockRefresh.mockRejectedValue(createAppError({ kind: 'Timeout', message: 'timeout' }));
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.isAuthenticated).toBe(false);
-    expect(mockClearRefreshToken).not.toHaveBeenCalled();
   });
 
   it('logout() clears tokens, sets isAuthenticated=false, and redirects', async () => {
@@ -356,9 +327,7 @@ describe('AuthProvider / useAuth', () => {
     });
 
     mockGetRefreshToken.mockResolvedValue('good-refresh');
-    mockRefresh.mockResolvedValue(
-      makeSession({ accessToken: 'fresh-access', refreshToken: 'fresh-refresh' }),
-    );
+    mockRunAuthRefresh.mockResolvedValue({ kind: 'success', accessToken: 'fresh-access' });
 
     let validity = false;
     await act(async () => {
@@ -366,7 +335,26 @@ describe('AuthProvider / useAuth', () => {
     });
 
     expect(validity).toBe(true);
-    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('checkTokenValidity() returns false on terminal refresh failure', async () => {
+    mockGetRefreshToken.mockResolvedValue('valid-refresh');
+    mockGetPersistedAccessToken.mockResolvedValue('cached');
+    mockIsAccessTokenExpired.mockReturnValue(false);
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    mockRunAuthRefresh.mockResolvedValue({ kind: 'invalid' });
+
+    let validity = true;
+    await act(async () => {
+      validity = await result.current.checkTokenValidity();
+    });
+
+    expect(validity).toBe(false);
   });
 
   it('checkTokenValidity() returns false when no refreshToken', async () => {
@@ -410,30 +398,60 @@ describe('AuthProvider / useAuth', () => {
   });
 
   // ── Onboarding state ──
+  //
+  // Bootstrap no longer calls /auth/refresh, so the authoritative
+  // onboardingCompleted flag is now produced by the registered auth refresh
+  // handler (when the response interceptor refreshes on the first 401) or by
+  // loginWithSession on a fresh login. The ex-bootstrap-refresh tests have
+  // been moved to the refresh-handler path below.
 
-  it('bootstrap with onboardingCompleted=false (via refresh) sets isFirstLaunch=true', async () => {
+  it('refresh handler with onboardingCompleted=false sets isFirstLaunch=true', async () => {
     mockGetRefreshToken.mockResolvedValue('valid-refresh');
-    mockIsAccessTokenExpired.mockReturnValue(true);
+    mockGetPersistedAccessToken.mockResolvedValue('cached');
+    mockIsAccessTokenExpired.mockReturnValue(false);
     mockRefresh.mockResolvedValue(makeSession({ user: { onboardingCompleted: false } }));
 
+    const httpClient = require('@/shared/infrastructure/httpClient');
     const { result } = renderHook(() => useAuth(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(httpClient.setAuthRefreshHandler).toHaveBeenCalled();
+    });
+
+    const handler = (httpClient.setAuthRefreshHandler as jest.Mock).mock.calls
+      .map((call: unknown[]) => call[0])
+      .find((arg: unknown): arg is () => Promise<unknown> => typeof arg === 'function');
+
+    expect(handler).toBeDefined();
+
+    await act(async () => {
+      await handler?.();
     });
 
     expect(result.current.isFirstLaunch).toBe(true);
   });
 
-  it('bootstrap with onboardingCompleted=true (via refresh) sets isFirstLaunch=false', async () => {
+  it('refresh handler with onboardingCompleted=true sets isFirstLaunch=false', async () => {
     mockGetRefreshToken.mockResolvedValue('valid-refresh');
-    mockIsAccessTokenExpired.mockReturnValue(true);
+    mockGetPersistedAccessToken.mockResolvedValue('cached');
+    mockIsAccessTokenExpired.mockReturnValue(false);
     mockRefresh.mockResolvedValue(makeSession({ user: { onboardingCompleted: true } }));
 
+    const httpClient = require('@/shared/infrastructure/httpClient');
     const { result } = renderHook(() => useAuth(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(httpClient.setAuthRefreshHandler).toHaveBeenCalled();
+    });
+
+    const handler = (httpClient.setAuthRefreshHandler as jest.Mock).mock.calls
+      .map((call: unknown[]) => call[0])
+      .find((arg: unknown): arg is () => Promise<unknown> => typeof arg === 'function');
+
+    expect(handler).toBeDefined();
+
+    await act(async () => {
+      await handler?.();
     });
 
     expect(result.current.isFirstLaunch).toBe(false);
@@ -453,13 +471,13 @@ describe('AuthProvider / useAuth', () => {
 
   it('markOnboardingComplete() calls API and sets isFirstLaunch=false', async () => {
     mockGetRefreshToken.mockResolvedValue('valid-refresh');
-    mockIsAccessTokenExpired.mockReturnValue(true);
-    mockRefresh.mockResolvedValue(makeSession({ user: { onboardingCompleted: false } }));
+    mockGetPersistedAccessToken.mockResolvedValue('cached');
+    mockIsAccessTokenExpired.mockReturnValue(false);
 
     const { result } = renderHook(() => useAuth(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isFirstLaunch).toBe(true);
+      expect(result.current.isLoading).toBe(false);
     });
 
     await act(async () => {

--- a/museum-frontend/app/auth.tsx
+++ b/museum-frontend/app/auth.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView, Text, View } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '@/features/auth/application/AuthContext';
+import { useBiometricAuth } from '@/features/auth/application/useBiometricAuth';
 import { useEmailPasswordAuth } from '@/features/auth/application/useEmailPasswordAuth';
 import { useForgotPassword } from '@/features/auth/application/useForgotPassword';
 import { useSocialLogin } from '@/features/auth/application/useSocialLogin';
@@ -12,6 +13,7 @@ import { AuthActionMenu } from '@/features/auth/ui/AuthActionMenu';
 import { AuthHeader } from '@/features/auth/ui/AuthHeader';
 import { AuthModeSwitchButton } from '@/features/auth/ui/AuthModeSwitchButton';
 import { AuthSeparator } from '@/features/auth/ui/AuthSeparator';
+import { BiometricSetupSheet } from '@/features/auth/ui/BiometricSetupSheet';
 import { LoginForm } from '@/features/auth/ui/LoginForm';
 import { RegisterForm } from '@/features/auth/ui/RegisterForm';
 import { SocialLoginButtons } from '@/features/auth/ui/SocialLoginButtons';
@@ -41,10 +43,55 @@ export default function AuthScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
   const [gdprAccepted, setGdprAccepted] = useState(false);
+  const [showBiometricSheet, setShowBiometricSheet] = useState(false);
   const { loginWithSession } = useAuth();
+  type Session = Parameters<typeof loginWithSession>[0];
+  const pendingSessionRef = useRef<Session | null>(null);
+  const biometric = useBiometricAuth();
+
+  // Wraps the auth-context loginWithSession so that, on first successful login
+  // when biometrics are available but not enrolled yet, we open the setup
+  // sheet BEFORE flipping isAuthenticated. Otherwise the navigation guard
+  // would unmount the auth screen and the sheet would never display.
+  const loginWithSessionWithBiometricPrompt = useCallback(
+    async (session: Session): Promise<void> => {
+      if (biometric.isAvailable && !biometric.isEnabled) {
+        pendingSessionRef.current = session;
+        setShowBiometricSheet(true);
+        return;
+      }
+      await loginWithSession(session);
+    },
+    [biometric.isAvailable, biometric.isEnabled, loginWithSession],
+  );
+
+  const finalizePendingSession = useCallback(async (): Promise<void> => {
+    const session = pendingSessionRef.current;
+    pendingSessionRef.current = null;
+    setShowBiometricSheet(false);
+    if (session) {
+      await loginWithSession(session);
+    }
+  }, [loginWithSession]);
+
+  const handleBiometricActivate = useCallback(async (): Promise<void> => {
+    try {
+      await biometric.enable();
+    } finally {
+      await finalizePendingSession();
+    }
+  }, [biometric, finalizePendingSession]);
+
+  const handleBiometricSkip = useCallback(() => {
+    void finalizePendingSession();
+  }, [finalizePendingSession]);
 
   const { handleAppleSignIn, handleGoogleSignIn, isSocialLoading, appleAuthAvailable } =
-    useSocialLogin({ loginWithSession, setErrorMessage, setInfoMessage });
+    useSocialLogin({
+      loginWithSession: loginWithSessionWithBiometricPrompt,
+      setErrorMessage,
+      setInfoMessage,
+    });
 
   const { handleForgotPassword } = useForgotPassword({
     email,
@@ -65,7 +112,7 @@ export default function AuthScreen() {
     password,
     firstname,
     lastname,
-    loginWithSession,
+    loginWithSession: loginWithSessionWithBiometricPrompt,
     setIsLoading,
     setErrorMessage,
     setInfoMessage,
@@ -183,6 +230,13 @@ export default function AuthScreen() {
           </GlassCard>
         </ScrollView>
       </KeyboardAvoidingView>
+
+      <BiometricSetupSheet
+        visible={showBiometricSheet}
+        biometricLabel={biometric.biometricLabel}
+        onActivate={handleBiometricActivate}
+        onSkip={handleBiometricSkip}
+      />
     </LiquidScreen>
   );
 }

--- a/museum-frontend/features/auth/application/AuthContext.tsx
+++ b/museum-frontend/features/auth/application/AuthContext.tsx
@@ -21,6 +21,7 @@ import { useChatLocalCacheStore } from '@/features/chat/application/chatLocalCac
 import { clearDailyArtStorage } from '@/features/daily-art/application/logoutCleanup';
 import { reportError } from '@/shared/observability/errorReporting';
 import {
+  runAuthRefresh,
   setAuthRefreshHandler,
   setTokenProvider,
   setUnauthorizedHandler,
@@ -147,57 +148,25 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           return;
         }
 
-        // Try the persisted access token first — avoids an unconditional /refresh
-        // call on every app launch (which would log the user out on any transient
-        // network/backend failure at boot).
+        // Hydrate the cached access token regardless of expiry — the response
+        // interceptor's single-flight refresh handles renewal on the first 401
+        // (or on the first authed request if no token is set). Bootstrap MUST
+        // NOT issue its own /auth/refresh call: a parallel API call from the
+        // first screen mount would trigger a second concurrent refresh and the
+        // backend rotates the refresh token, invalidating whichever request
+        // arrives second → spurious logout on every cold start.
         const cachedAccess = await authStorage.getPersistedAccessToken();
-        if (cachedAccess && !isAccessTokenExpired(cachedAccess)) {
+        if (cachedAccess) {
           setAccessToken(cachedAccess);
-          setIsAuthenticated(true);
           identifySentryUser(cachedAccess);
-          const biometricOn = await getBiometricEnabled();
-          if (biometricOn) setIsBiometricLocked(true);
-          bootstrapBreadcrumb('token_valid', { duration_ms: Date.now() - startedAt });
-          return;
         }
-
-        // Access token missing or (near-)expired — attempt a refresh.
-        try {
-          const session = await authService.refresh(refreshToken);
-          await persistSessionTokens(session.accessToken, session.refreshToken);
-          setAccessToken(session.accessToken);
-          setIsAuthenticated(true);
-          setIsFirstLaunch(!session.user.onboardingCompleted);
-          identifySentryUser(session.accessToken);
-          const biometricOn = await getBiometricEnabled();
-          if (biometricOn) setIsBiometricLocked(true);
-        } catch (refreshError) {
-          if (isAuthInvalidError(refreshError)) {
-            await clearPersistedTokens();
-            setIsAuthenticated(false);
-            setIsFirstLaunch(true);
-            Sentry.setUser(null);
-            return;
-          }
-
-          // Network / timeout / 5xx: keep credentials so the user stays logged in
-          // when the app recovers connectivity. If a stale cached access token
-          // exists, use it — the next authed request will trigger another refresh.
-          if (cachedAccess) {
-            setAccessToken(cachedAccess);
-            setIsAuthenticated(true);
-            identifySentryUser(cachedAccess);
-            const biometricOn = await getBiometricEnabled();
-            if (biometricOn) setIsBiometricLocked(true);
-          } else {
-            // No cached access token and refresh failed transiently: stay on the
-            // auth screen for this launch, but keep the refresh token persisted
-            // so the next boot can retry.
-            setIsAuthenticated(false);
-            setIsFirstLaunch(null);
-          }
-          reportError(refreshError, { context: 'auth_bootstrap_refresh_transient' });
-        }
+        setIsAuthenticated(true);
+        const biometricOn = await getBiometricEnabled();
+        if (biometricOn) setIsBiometricLocked(true);
+        bootstrapBreadcrumb(cachedAccess ? 'token_hydrated' : 'token_pending_refresh', {
+          duration_ms: Date.now() - startedAt,
+          access_expired: cachedAccess ? isAccessTokenExpired(cachedAccess) : true,
+        });
       } catch (error) {
         reportError(error, { context: 'auth_bootstrap' });
         setIsAuthenticated(false);
@@ -217,17 +186,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, []);
 
   const silentRefresh = useCallback(async (): Promise<string | null> => {
-    const refreshToken = await authStorage.getRefreshToken();
-    if (!refreshToken) return null;
-    try {
-      const session = await authService.refresh(refreshToken);
-      await persistSessionTokens(session.accessToken, session.refreshToken);
-      setAccessToken(session.accessToken);
-      identifySentryUser(session.accessToken);
-      return session.accessToken;
-    } catch {
-      return null;
-    }
+    const result = await runAuthRefresh();
+    return result.kind === 'success' ? result.accessToken : null;
   }, []);
 
   useAuthAppStateSync(silentRefresh, {
@@ -248,7 +208,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setAuthRefreshHandler(async () => {
       const refreshToken = await authStorage.getRefreshToken();
       if (!refreshToken) {
-        return null;
+        return { kind: 'invalid' };
       }
 
       try {
@@ -258,18 +218,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setIsAuthenticated(true);
         setIsFirstLaunch(!session.user.onboardingCompleted);
         identifySentryUser(session.accessToken);
-        return session.accessToken;
+        return { kind: 'success', accessToken: session.accessToken };
       } catch (error) {
         if (isAuthInvalidError(error)) {
-          await clearPersistedTokens();
-          setIsAuthenticated(false);
-          Sentry.setUser(null);
-          return null;
+          return { kind: 'invalid' };
         }
-        // Network / 5xx during refresh: don't clear tokens. Surface null so the
-        // current request fails, but the next attempt can retry with the same
-        // refresh token.
-        return null;
+        // Network / 5xx during refresh: keep tokens intact so the next attempt
+        // can retry with the same refresh token. The pending request fails
+        // with its original 401 but the session survives the outage.
+        return { kind: 'transient' };
       }
     });
 
@@ -318,32 +275,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   const checkTokenValidity = async (): Promise<boolean> => {
-    try {
-      const refreshToken = await authStorage.getRefreshToken();
-      if (!refreshToken) {
-        await clearPersistedTokens();
-        setIsAuthenticated(false);
-        return false;
-      }
-
-      const session = await authService.refresh(refreshToken);
-      await persistSessionTokens(session.accessToken, session.refreshToken);
-      setAccessToken(session.accessToken);
-      setIsAuthenticated(true);
-      setIsFirstLaunch(!session.user.onboardingCompleted);
-      identifySentryUser(session.accessToken);
-      return true;
-    } catch (error) {
-      if (isAuthInvalidError(error)) {
-        await clearPersistedTokens();
-        setIsAuthenticated(false);
-        return false;
-      }
-      reportError(error, { context: 'token_validation' });
-      // Transient failure — preserve the session so the user can keep using
-      // the app; the next authed request will retry the refresh flow.
-      return isAuthenticated;
+    const refreshToken = await authStorage.getRefreshToken();
+    if (!refreshToken) {
+      await clearPersistedTokens();
+      setIsAuthenticated(false);
+      return false;
     }
+
+    const result = await runAuthRefresh();
+    if (result.kind === 'success') {
+      return true;
+    }
+    if (result.kind === 'invalid') {
+      // unauthorizedHandler has already purged the session for the shared cycle.
+      return false;
+    }
+    // Transient failure — preserve the session so the user can keep using
+    // the app; the next authed request will retry the refresh flow.
+    return isAuthenticated;
   };
 
   return (

--- a/museum-frontend/features/auth/ui/AuthHeader.tsx
+++ b/museum-frontend/features/auth/ui/AuthHeader.tsx
@@ -12,8 +12,9 @@ interface AuthHeaderProps {
 }
 
 /**
- * Branded header for the auth screen: Musaium logo + mode-aware title
- * and subtitle. Pure presentational component.
+ * Branded header for the auth screen: Musaium logo (left) + mode-aware
+ * title and subtitle (right) on a horizontal 50/50 row to keep the header
+ * compact and free vertical space for the form.
  */
 export function AuthHeader({ isLogin }: AuthHeaderProps) {
   const { t } = useTranslation();
@@ -21,13 +22,15 @@ export function AuthHeader({ isLogin }: AuthHeaderProps) {
 
   return (
     <View style={styles.header}>
-      <BrandMark variant="auth" />
-      <Text style={[styles.title, { color: theme.textPrimary }]}>
-        {isLogin ? t('auth.welcome_back') : t('auth.create_account')}
-      </Text>
-      <Text style={[styles.subtitle, { color: theme.textSecondary }]}>
-        {isLogin ? t('auth.sign_in_subtitle') : t('auth.sign_up_subtitle')}
-      </Text>
+      <BrandMark variant="auth-compact" />
+      <View style={styles.headerText}>
+        <Text style={[styles.title, { color: theme.textPrimary }]}>
+          {isLogin ? t('auth.welcome_back') : t('auth.create_account')}
+        </Text>
+        <Text style={[styles.subtitle, { color: theme.textSecondary }]} numberOfLines={2}>
+          {isLogin ? t('auth.sign_in_subtitle') : t('auth.sign_up_subtitle')}
+        </Text>
+      </View>
     </View>
   );
 }

--- a/museum-frontend/features/auth/ui/BiometricSetupSheet.tsx
+++ b/museum-frontend/features/auth/ui/BiometricSetupSheet.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Animated,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+
+import { useTheme } from '@/shared/ui/ThemeContext';
+import { fontSize, lineHeightPx, radius, semantic, space } from '@/shared/ui/tokens';
+
+interface BiometricSetupSheetProps {
+  /** Whether the sheet is visible. */
+  visible: boolean;
+  /** Human-readable label for the biometric method (e.g. "Face ID", "Touch ID"). */
+  biometricLabel: string;
+  /** Called when the user activates biometric login. May resolve even on auth cancel. */
+  onActivate: () => Promise<void>;
+  /** Called when the user dismisses the sheet without enrolling. */
+  onSkip: () => void;
+}
+
+const ANIMATION_DURATION_MS = 220;
+const SHEET_HIDDEN_OFFSET = 600;
+
+const pickIconName = (biometricLabel: string): keyof typeof Ionicons.glyphMap => {
+  if (biometricLabel.toLowerCase().includes('face')) {
+    return 'scan-outline';
+  }
+  return 'finger-print';
+};
+
+/**
+ * Bottom-sheet modal offered after first successful login to invite the
+ * user to enroll biometric authentication. Skip-able, never blocking.
+ */
+export function BiometricSetupSheet({
+  visible,
+  biometricLabel,
+  onActivate,
+  onSkip,
+}: BiometricSetupSheetProps) {
+  const { t } = useTranslation();
+  const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
+  const translateY = useRef(new Animated.Value(SHEET_HIDDEN_OFFSET)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+  const [isActivating, setIsActivating] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.timing(translateY, {
+          toValue: 0,
+          duration: ANIMATION_DURATION_MS,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: ANIMATION_DURATION_MS,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else {
+      translateY.setValue(SHEET_HIDDEN_OFFSET);
+      opacity.setValue(0);
+    }
+  }, [visible, translateY, opacity]);
+
+  const handleActivate = async (): Promise<void> => {
+    if (isActivating) return;
+    setIsActivating(true);
+    try {
+      await onActivate();
+    } finally {
+      setIsActivating(false);
+    }
+  };
+
+  const titleText = t('auth.biometric_setup.title', {
+    defaultValue: `Activer ${biometricLabel} ?`,
+    method: biometricLabel,
+  });
+  const descriptionText = t('auth.biometric_setup.description', {
+    defaultValue: 'Connectez-vous plus rapidement la prochaine fois.',
+  });
+  const activateText = t('auth.biometric_setup.activate', {
+    defaultValue: 'Activer',
+  });
+  const laterText = t('auth.biometric_setup.later', {
+    defaultValue: 'Plus tard',
+  });
+
+  const sheetStyle: StyleProp<ViewStyle> = [
+    styles.sheet,
+    {
+      backgroundColor: theme.surface,
+      borderColor: theme.cardBorder,
+      paddingBottom: Math.max(insets.bottom, space['4']) + space['4'],
+      transform: [{ translateY }],
+    },
+  ];
+
+  const iconName = pickIconName(biometricLabel);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={onSkip}
+      statusBarTranslucent
+    >
+      <Animated.View
+        style={[styles.backdrop, { backgroundColor: theme.modalOverlay, opacity }]}
+        pointerEvents={visible ? 'auto' : 'none'}
+      >
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onSkip}
+          accessibilityLabel={laterText}
+          accessibilityRole="button"
+        />
+        <Animated.View style={sheetStyle}>
+          <View style={[styles.iconBubble, { backgroundColor: theme.primaryTint }]}>
+            <Ionicons name={iconName} size={32} color={theme.primary} />
+          </View>
+          <Text style={[styles.title, { color: theme.textPrimary }]}>{titleText}</Text>
+          <Text style={[styles.description, { color: theme.textSecondary }]}>
+            {descriptionText}
+          </Text>
+
+          <Pressable
+            style={({ pressed }) => [
+              styles.primaryButton,
+              { backgroundColor: theme.primary },
+              pressed ? styles.pressed : null,
+              isActivating ? styles.disabled : null,
+            ]}
+            onPress={() => {
+              void handleActivate();
+            }}
+            disabled={isActivating}
+            accessibilityRole="button"
+            accessibilityLabel={activateText}
+          >
+            <Text style={[styles.primaryButtonText, { color: theme.primaryContrast }]}>
+              {activateText}
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={({ pressed }) => [styles.secondaryButton, pressed ? styles.pressed : null]}
+            onPress={onSkip}
+            accessibilityRole="button"
+            accessibilityLabel={laterText}
+          >
+            <Text style={[styles.secondaryButtonText, { color: theme.textSecondary }]}>
+              {laterText}
+            </Text>
+          </Pressable>
+        </Animated.View>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    paddingHorizontal: semantic.card.paddingLarge,
+    paddingTop: semantic.card.paddingLarge,
+    borderTopLeftRadius: radius['3xl'],
+    borderTopRightRadius: radius['3xl'],
+    borderTopWidth: semantic.input.borderWidth,
+    borderLeftWidth: semantic.input.borderWidth,
+    borderRightWidth: semantic.input.borderWidth,
+    alignItems: 'center',
+    gap: space['3'],
+  },
+  iconBubble: {
+    width: 64,
+    height: 64,
+    borderRadius: radius['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: fontSize.xl,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: fontSize.sm,
+    lineHeight: lineHeightPx['21'],
+    textAlign: 'center',
+  },
+  primaryButton: {
+    width: '100%',
+    borderRadius: semantic.button.radius,
+    paddingVertical: semantic.button.paddingYCompact,
+    alignItems: 'center',
+    marginTop: space['2'],
+  },
+  primaryButtonText: {
+    fontSize: fontSize['base-'],
+    fontWeight: '700',
+  },
+  secondaryButton: {
+    width: '100%',
+    paddingVertical: semantic.button.paddingY,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    fontSize: semantic.button.fontSize,
+    fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+  disabled: {
+    opacity: 0.6,
+  },
+});

--- a/museum-frontend/features/auth/ui/authStyles.ts
+++ b/museum-frontend/features/auth/ui/authStyles.ts
@@ -30,17 +30,24 @@ export const authStyles = StyleSheet.create({
     gap: semantic.form.gapLarge,
   },
   header: {
+    flexDirection: 'row',
     alignItems: 'center',
-    gap: semantic.section.gapTight,
+    justifyContent: 'center',
+    gap: space['4'],
+  },
+  headerText: {
+    flex: 1,
+    alignItems: 'flex-start',
+    gap: space['1'],
   },
   title: {
-    fontSize: semantic.section.titleSizeHero,
+    fontSize: fontSize.xl,
     fontWeight: '700',
-    textAlign: 'center',
+    textAlign: 'left',
   },
   subtitle: {
     fontSize: fontSize.sm,
-    textAlign: 'center',
+    textAlign: 'left',
     lineHeight: lineHeightPx['21'],
   },
   form: {

--- a/museum-frontend/shared/infrastructure/httpClient.ts
+++ b/museum-frontend/shared/infrastructure/httpClient.ts
@@ -8,13 +8,25 @@ import { getApiErrorCode, mapAxiosError, toAxiosLikeError } from './httpErrorMap
 import { getCurrentDataMode } from './dataMode/currentDataMode';
 
 type UnauthorizedHandler = () => void;
-type AuthRefreshHandler = () => Promise<string | null>;
+
+/**
+ * Outcome of an auth refresh attempt.
+ *
+ * - `success` → new access token issued, retry the original request.
+ * - `invalid` → backend rejected the refresh token (401/403); purge session.
+ * - `transient` → network / timeout / 5xx; keep session, fail the current request.
+ */
+export type AuthRefreshResult =
+  | { kind: 'success'; accessToken: string }
+  | { kind: 'invalid' }
+  | { kind: 'transient' };
+
+type AuthRefreshHandler = () => Promise<AuthRefreshResult>;
 type TokenProvider = () => string | null;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- assigned via setter, used in interceptor
 let unauthorizedHandler: UnauthorizedHandler | null = null;
 let authRefreshHandler: AuthRefreshHandler | null = null;
-let authRefreshInFlight: Promise<string | null> | null = null;
+let inflightRefresh: Promise<AuthRefreshResult> | null = null;
 let tokenProvider: TokenProvider | null = null;
 
 /**
@@ -26,7 +38,9 @@ export const setTokenProvider = (fn: TokenProvider | null): void => {
 };
 
 /**
- * Registers a callback invoked when a 401 response is received on an authenticated request.
+ * Registers a callback invoked once per refresh cycle when the refresh token
+ * is rejected as invalid (terminal failure). All concurrent 401-bound requests
+ * share a single firing — the handler runs at most once per cycle.
  * @param handler - Handler function, or `null` to unregister.
  */
 export const setUnauthorizedHandler = (handler: UnauthorizedHandler | null): void => {
@@ -34,11 +48,54 @@ export const setUnauthorizedHandler = (handler: UnauthorizedHandler | null): voi
 };
 
 /**
- * Registers a handler that attempts to refresh the access token on 401 responses.
- * @param handler - Async function returning a new access token (or `null` on failure), or `null` to unregister.
+ * Registers a handler that attempts to refresh the access token. It MUST
+ * disambiguate terminal failures (`invalid`) from transient ones (`transient`)
+ * so the http client can fire the unauthorized handler only when the backend
+ * explicitly rejects the refresh token.
+ * @param handler - Async function returning an {@link AuthRefreshResult}, or `null` to unregister.
  */
 export const setAuthRefreshHandler = (handler: AuthRefreshHandler | null): void => {
   authRefreshHandler = handler;
+};
+
+/**
+ * Single-flight wrapper around the registered auth refresh handler. Concurrent
+ * callers await the same in-flight Promise; the unauthorized handler fires
+ * exactly once when the cycle resolves to `invalid`.
+ *
+ * @returns The shared {@link AuthRefreshResult} for the current cycle, or
+ *          `{ kind: 'transient' }` when no handler is registered.
+ */
+export const runAuthRefresh = async (): Promise<AuthRefreshResult> => {
+  if (!authRefreshHandler) {
+    return { kind: 'transient' };
+  }
+  if (inflightRefresh) {
+    return inflightRefresh;
+  }
+
+  const handler = authRefreshHandler;
+  const cycle = (async (): Promise<AuthRefreshResult> => {
+    let result: AuthRefreshResult;
+    try {
+      result = await handler();
+    } catch {
+      result = { kind: 'transient' };
+    }
+    if (result.kind === 'invalid') {
+      try {
+        unauthorizedHandler?.();
+      } catch {
+        // Never let the logout side effect crash queued waiters.
+      }
+    }
+    return result;
+  })();
+
+  inflightRefresh = cycle.finally(() => {
+    inflightRefresh = null;
+  });
+  return inflightRefresh;
 };
 
 type HttpRequestConfig = {
@@ -180,27 +237,18 @@ httpClient.interceptors.response.use(
       authRefreshHandler &&
       axiosError?.config
     ) {
-      try {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- multi-line promise guard, ??= less readable
-        if (!authRefreshInFlight) {
-          authRefreshInFlight = authRefreshHandler().finally(() => {
-            authRefreshInFlight = null;
-          });
-        }
-
-        const nextAccessToken = await authRefreshInFlight;
-        if (nextAccessToken) {
-          config._retriedAfterAuthRefresh = true;
-          const headers = (axiosError.config.headers ?? {}) as Record<string, unknown>;
-          axiosError.config.headers = {
-            ...headers,
-            Authorization: `Bearer ${nextAccessToken}`,
-          };
-          return await httpClient.request(axiosError.config as never);
-        }
-      } catch {
-        // Fall through to standard error mapping / unauthorized handling.
+      const refreshResult = await runAuthRefresh();
+      if (refreshResult.kind === 'success') {
+        config._retriedAfterAuthRefresh = true;
+        const headers = (axiosError.config.headers ?? {}) as Record<string, unknown>;
+        axiosError.config.headers = {
+          ...headers,
+          Authorization: `Bearer ${refreshResult.accessToken}`,
+        };
+        return await httpClient.request(axiosError.config as never);
       }
+      // `invalid` → unauthorizedHandler already fired exactly once for the
+      // shared cycle. `transient` → fall through and let the request fail.
     }
 
     const is429 = status === 429;

--- a/museum-frontend/shared/locales/ar/translation.json
+++ b/museum-frontend/shared/locales/ar/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "سياسة الخصوصية",
     "badge_style": "أسلوب",
     "badge_guide": "مرشد",
-    "badge_safe": "آمن"
+    "badge_safe": "آمن",
+    "biometric_setup": {
+      "title": "تفعيل {{method}}؟",
+      "description": "سجّل الدخول بشكل أسرع في المرة القادمة.",
+      "activate": "تفعيل",
+      "later": "لاحقاً"
+    }
   },
   "home": {
     "hero_title": "رفيقك في المتحف",

--- a/museum-frontend/shared/locales/de/translation.json
+++ b/museum-frontend/shared/locales/de/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "Datenschutzerklärung",
     "badge_style": "Stil",
     "badge_guide": "Begleitung",
-    "badge_safe": "Sicher"
+    "badge_safe": "Sicher",
+    "biometric_setup": {
+      "title": "{{method}} aktivieren?",
+      "description": "Beim nächsten Mal schneller anmelden.",
+      "activate": "Aktivieren",
+      "later": "Später"
+    }
   },
   "home": {
     "hero_title": "Ihr Museumsbegleiter",

--- a/museum-frontend/shared/locales/en/translation.json
+++ b/museum-frontend/shared/locales/en/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "Privacy Policy",
     "badge_style": "Style",
     "badge_guide": "Guide",
-    "badge_safe": "Safe"
+    "badge_safe": "Safe",
+    "biometric_setup": {
+      "title": "Enable {{method}}?",
+      "description": "Sign in faster next time.",
+      "activate": "Enable",
+      "later": "Later"
+    }
   },
   "home": {
     "hero_title": "Your museum companion",

--- a/museum-frontend/shared/locales/es/translation.json
+++ b/museum-frontend/shared/locales/es/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "Política de Privacidad",
     "badge_style": "Estilo",
     "badge_guide": "Guía",
-    "badge_safe": "Seguro"
+    "badge_safe": "Seguro",
+    "biometric_setup": {
+      "title": "¿Activar {{method}}?",
+      "description": "Inicia sesión más rápido la próxima vez.",
+      "activate": "Activar",
+      "later": "Más tarde"
+    }
   },
   "home": {
     "hero_title": "Tu compañero de museo",

--- a/museum-frontend/shared/locales/fr/translation.json
+++ b/museum-frontend/shared/locales/fr/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "Politique de confidentialité",
     "badge_style": "Style",
     "badge_guide": "Guide",
-    "badge_safe": "Sûr"
+    "badge_safe": "Sûr",
+    "biometric_setup": {
+      "title": "Activer {{method}} ?",
+      "description": "Connectez-vous plus rapidement la prochaine fois.",
+      "activate": "Activer",
+      "later": "Plus tard"
+    }
   },
   "home": {
     "hero_title": "Votre compagnon de musée",

--- a/museum-frontend/shared/locales/it/translation.json
+++ b/museum-frontend/shared/locales/it/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "Informativa sulla Privacy",
     "badge_style": "Stile",
     "badge_guide": "Guida",
-    "badge_safe": "Sicuro"
+    "badge_safe": "Sicuro",
+    "biometric_setup": {
+      "title": "Attivare {{method}}?",
+      "description": "Accedi più velocemente la prossima volta.",
+      "activate": "Attiva",
+      "later": "Più tardi"
+    }
   },
   "home": {
     "hero_title": "Il tuo compagno di museo",

--- a/museum-frontend/shared/locales/ja/translation.json
+++ b/museum-frontend/shared/locales/ja/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "プライバシーポリシー",
     "badge_style": "スタイル",
     "badge_guide": "ガイド",
-    "badge_safe": "安全"
+    "badge_safe": "安全",
+    "biometric_setup": {
+      "title": "{{method}}を有効にしますか？",
+      "description": "次回からすばやくサインインできます。",
+      "activate": "有効化",
+      "later": "後で"
+    }
   },
   "home": {
     "hero_title": "あなたの美術館コンパニオン",

--- a/museum-frontend/shared/locales/zh/translation.json
+++ b/museum-frontend/shared/locales/zh/translation.json
@@ -63,7 +63,13 @@
     "privacy_policy": "隐私政策",
     "badge_style": "风格",
     "badge_guide": "导览",
-    "badge_safe": "安全"
+    "badge_safe": "安全",
+    "biometric_setup": {
+      "title": "启用{{method}}？",
+      "description": "下次更快登录。",
+      "activate": "启用",
+      "later": "稍后"
+    }
   },
   "home": {
     "hero_title": "您的博物馆伴侣",

--- a/museum-frontend/shared/ui/BrandMark.tsx
+++ b/museum-frontend/shared/ui/BrandMark.tsx
@@ -11,7 +11,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- RN image require pattern
 const musaiumLogo = require('../../assets/images/logo.png') as ImageSourcePropType;
 
-type BrandMarkVariant = 'auth' | 'hero' | 'header';
+type BrandMarkVariant = 'auth' | 'auth-compact' | 'hero' | 'header';
 
 interface BrandMarkProps {
   variant?: BrandMarkVariant;
@@ -26,6 +26,10 @@ const clamp = (value: number, min: number, max: number) => {
 const resolveResponsiveSize = (variant: BrandMarkVariant, viewportWidth: number) => {
   if (variant === 'auth') {
     return clamp(Math.round(viewportWidth * 0.34), 96, 132);
+  }
+
+  if (variant === 'auth-compact') {
+    return clamp(Math.round(viewportWidth * 0.18), 64, 80);
   }
 
   if (variant === 'header') {


### PR DESCRIPTION
## Summary

- **Fixes re-login-on-app-quit bug**: production logs showed two concurrent `/api/auth/refresh` calls firing within ~20ms of each other on cold start. The first rotated the refresh token, the second hit 401 with the now-invalidated token, and the client purged the session. Fix: single-flight mutex in `httpClient.ts` + drop the duplicate refresh in `AuthContext` bootstrap.
- **Reshapes login screen** to a 50/50 row layout (compact BrandMark left, title + subtitle right, title `28 -> 20`) so the form and Conditions footer fit on a single screen without overflow.
- **Adds Face ID enrollment bottom sheet** that surfaces non-blocking after successful first login when biometric is available and not yet enabled. Covers email/password and social login flows.

## Files

- `museum-frontend/shared/infrastructure/httpClient.ts` — discriminated `AuthRefreshResult`, module-level `runAuthRefresh()` single-flight coordinator
- `museum-frontend/features/auth/application/AuthContext.tsx` — drop bootstrap refresh, route `silentRefresh` + `checkTokenValidity` through `runAuthRefresh`
- `museum-frontend/features/auth/ui/AuthHeader.tsx` + `authStyles.ts` — row layout, reduced title size
- `museum-frontend/shared/ui/BrandMark.tsx` — `auth-compact` variant (~64px)
- `museum-frontend/features/auth/ui/BiometricSetupSheet.tsx` (new) — themed bottom sheet, animated in/out, skip-able
- `museum-frontend/app/auth.tsx` — `loginWithSession` wrapper triggers the sheet on first login
- `museum-frontend/shared/locales/{fr,en}/translation.json` — `auth.biometric_setup.*`
- `__tests__/context/AuthContext.test.tsx` — contract updated, 15 tests pass

## Test plan

- [ ] Cold-start the app while logged in -> stays logged in (regression test for the refresh race)
- [ ] Login screen: logo + title fit on one line at 50/50, no form / footer clipping on iPhone SE / 13 / 15 Pro Max
- [ ] First login on a clean install -> Face ID sheet appears, "Activer" enrolls, "Plus tard" skips, both navigate forward
- [ ] Subsequent logins do not re-prompt the sheet
- [ ] Social login (Apple / Google) on first connect -> sheet also appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)