### PR TITLE
fix(c1-followup): prometheus.yml refactor + 2 copy/comment nits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Leçons techniques non évidentes consolidées des sprints précédents. Ajoute 
 - **PgBouncer transaction mode interdit `LISTEN/NOTIFY`, session-scoped advisory locks, persistent prepared statements** — Musaium n'utilise rien de ça aujourd'hui (audit ADR-021), mais à vérifier au cas par cas.
 - **SWC + TypeORM cross-entity = ReferenceError circular** — fix = wrap les FK avec le type alias `Relation<T>`. Ne pas s'écarter de ce pattern sur les nouvelles entités.
 - **LLM response cache = `LlmCacheServiceImpl` only (ADR-036)** — un seul layer, use-case-level. Ne PAS réintroduire de décorateur adapter-level (`CachingChatOrchestrator` supprimé 2026-05-08 PR-B). Cache key shape = `llm:v1:{contextClass}:{museumId|none}:{userId|anon}:{sha256}`. TTL tune = data-driven only, ≥7j bake + ADR-036 amendment requis (R11/R13).
+- **Prometheus `static_configs.targets` n'expand PAS `${VAR}`** — seul `external_labels` accepte `${VAR}` (avec `--enable-feature=expand-external-labels`). Pour différencier prod/dev, on monte 2 fichiers distincts : `infra/grafana/prometheus.yml` (target `backend:3000` pour prod, scp'd via CI vers `/srv/museum/obs/`) et `infra/grafana/prometheus.local.yml` (target `host.docker.internal:3000` pour le local stack `infra/grafana/docker-compose*.yml`). Ne pas tenter de paramétrer le target via env — c'est silencieusement ignoré.
 
 ## Environment Setup
 

--- a/infra/grafana/docker-compose.yml
+++ b/infra/grafana/docker-compose.yml
@@ -13,7 +13,13 @@ services:
     environment:
       ENV: "${ENV:-production}"
     volumes:
-      - ../../museum-backend/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # Local standalone stack — backend runs on the host (pnpm dev), so
+      # we mount prometheus.local.yml whose scrape target is
+      # host.docker.internal:3000 (paired with the extra_hosts entry
+      # below). Production uses the sibling prometheus.yml (target
+      # backend:3000) mounted by museum-backend/deploy/docker-compose.prod.yml
+      # via the obs/ rsync from CI.
+      - ./prometheus.local.yml:/etc/prometheus/prometheus.yml:ro
       - ./alerting:/etc/prometheus/alerting:ro
       - prom_data:/prometheus
     ports:

--- a/infra/grafana/prometheus.local.yml
+++ b/infra/grafana/prometheus.local.yml
@@ -1,0 +1,34 @@
+# Local-dev Prometheus scrape config. Same shape as prometheus.yml,
+# but the scrape target is `host.docker.internal:3000` so the local
+# Grafana/Prom/AM stack (infra/grafana/docker-compose.local.yml) can
+# reach a backend running on the host (`pnpm dev`).
+#
+# Mounted by infra/grafana/docker-compose.local.yml override of the
+# prometheus service. Production compose continues to mount the
+# sibling `prometheus.yml` (target = backend:3000 on the `private`
+# Docker network).
+
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  evaluation_interval: 30s
+  external_labels:
+    service: musaium-backend
+    env: ${ENV}
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - /etc/prometheus/alerting/*.yml
+
+scrape_configs:
+  - job_name: musaium-backend
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - "host.docker.internal:3000"
+        labels:
+          service: musaium-backend

--- a/infra/grafana/prometheus.yml
+++ b/infra/grafana/prometheus.yml
@@ -24,12 +24,20 @@ rule_files:
 scrape_configs:
   - job_name: musaium-backend
     metrics_path: /metrics
-    # Compose sets `extra_hosts: host.docker.internal:host-gateway` so the
-    # Prom container can reach a backend running on the host. In a fully-
-    # Compose deploy where the backend is a service on the same network,
-    # change this to the service hostname (`musaium-backend:3000`).
+    # `backend:3000` resolves via Docker DNS because the prometheus
+    # service in /srv/museum/docker-compose.yml joins the `private`
+    # network alongside the backend container. `obs` is also attached
+    # for AlertManager + Grafana connectivity ; the scrape target sits
+    # on `private`.
+    #
+    # Prometheus does NOT expand ${VAR} inside `static_configs.targets`
+    # (only `external_labels` accepts that flag). For local dev where
+    # the backend runs on the host (pnpm dev), use the sibling file
+    # prometheus.local.yml (target = host.docker.internal:3000) — the
+    # local-stack compose at infra/grafana/docker-compose.local.yml
+    # overrides this volume mount accordingly.
     static_configs:
       - targets:
-          - "host.docker.internal:3000"
+          - "backend:3000"
         labels:
           service: musaium-backend

--- a/museum-backend/tests/integration/_smoke/integration-tier-baseline-cap.test.ts
+++ b/museum-backend/tests/integration/_smoke/integration-tier-baseline-cap.test.ts
@@ -14,7 +14,7 @@ const BASELINE_PATH = join(REPO_ROOT, 'scripts/sentinels/.integration-tier-basel
 // 2026-05-09 (C1 PR-G): bumped 2 → 4 to admit the two PR-A integration
 // tests pinning chat-pipeline span emission (R1/R2) and admin↔chat
 // invalidateMuseum contract (R9). Both have justifications + approval
-// refs in the baseline JSON. Reduce back to 4 only by deleting one of
+// refs in the baseline JSON. Reduce back to 2 only by deleting one of
 // those entries, never by adding more.
 const PHASE_1_BASELINE_CAP = 4;
 

--- a/museum-web/src/app/[locale]/admin/ops/grafana/page.tsx
+++ b/museum-web/src/app/[locale]/admin/ops/grafana/page.tsx
@@ -15,7 +15,7 @@ export default function OpsGrafanaPage() {
         <h1 className="text-2xl font-bold text-text-primary">Chat latency — ops view</h1>
         <p className="mt-1 text-text-secondary">
           Self-hosted Grafana panel embedded same-origin. Data scope: all tenants. Restricted
-          to <code>admin</code> role. See{' '}
+          to <code>super_admin</code> role. See{' '}
           <code>docs/OPS_DEPLOYMENT.md</code> §Grafana iframe limitation for the threat model.
         </p>
       </header>


### PR DESCRIPTION
## Summary

Follow-up to PR #207 (C1 bundle merged at \`63dfab3c\`) addressing the
post-merge fresh-context reviewer findings (89.45/100, 1 IMPORTANT + 2 NITs)
plus a 3-angle re-review (security + correctness + maintainability) that
converged on \`CHANGES_REQUESTED\` for the original prometheus.yml patch.

### What changed

**1. Prometheus config — refactor for actual prod ↔ local parity**

The previous attempt edited \`museum-backend/prometheus.yml\`, but CI scp
sources \`infra/grafana/*\` only — so the patched file was never shipped
to prod, and the local Grafana stack mounting the same file would have
broken silently (\`backend:3000\` does not resolve on the local \`obs\`-only network).

- \`git mv museum-backend/prometheus.yml → infra/grafana/prometheus.yml\` — CI rsync now ships it.
- New \`infra/grafana/prometheus.local.yml\` with \`host.docker.internal:3000\` for the standalone local stack.
- \`infra/grafana/docker-compose.yml\` mounts the local variant ; \`museum-backend/deploy/docker-compose.prod.yml\` continues mounting the prod variant (via \`./obs/prometheus.yml\` after CI rsync).
- Comment in \`prometheus.yml\` reworded — drops the misleading "override via env" claim (Prometheus \`static_configs.targets\` does NOT expand \`\${VAR}\`).

**2. Copy fix — admin role → super_admin role**

\`museum-web/src/app/[locale]/admin/ops/grafana/page.tsx:18\` now matches
the three enforcement layers (RoleGuard, nginx auth_request, BE
endpoint), all of which gate \`super_admin\`.

**3. Comment fix — baseline cap "back to 2"**

\`tests/integration/_smoke/integration-tier-baseline-cap.test.ts:17\` —
typo from the 2 → 4 bump in PR-G ; "Reduce back to 4" was tautological,
now reads "back to 2".

**4. CLAUDE.md piège**

New entry under \`Pièges connus\` warning that Prometheus
\`static_configs.targets\` does not expand \`\${VAR}\` — operators must
mount distinct files for prod vs local.

## Test plan

- [x] tsc + scoped jest pass locally (2/2 baseline-cap test).
- [x] yaml.safe_load on prometheus.yml + prometheus.local.yml + docker-compose.yml + docker-compose.local.yml (4/4 valid).
- [x] CI rsync source path verified: \`infra/grafana/*\` → \`/srv/museum/obs/\` (\`ci-cd-backend.yml\` deploy-prod \`Sync prod compose + obs config to VPS\`).
- [ ] CI green (Stryker stays \`if: false\` until local cache-builder lands).
- [ ] Post-deploy: \`docker exec musaium-prometheus wget -qO- :9090/api/v1/targets\` shows \`backend:3000\` UP.

## Stryker note

Mutation job remains disabled (\`if: false\` from \`6807bfe9\`) — the
local cache-builder agent owns regeneration. Restore conditional once
the cache lands in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)