### PR TITLE
fix(deploy): unblock prod build — install curl + graceful skip when bucket missing

### DIFF
--- a/museum-backend/deploy/Dockerfile.prod
+++ b/museum-backend/deploy/Dockerfile.prod
@@ -5,6 +5,12 @@
 FROM node:22-bookworm-slim AS build
 WORKDIR /app
 
+# `curl` is required by museum-backend/scripts/fetch-models.sh (C3 SigLIP
+# ONNX bundle). node:22-bookworm-slim does not ship curl.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable && corepack prepare pnpm@9.15.3 --activate
 
 # Copy the workspace plugin FIRST so the file:.. path exists when pnpm
@@ -21,8 +27,11 @@ RUN pnpm run build
 # Idempotent: skips re-download when the file is already present and (when
 # configured via SIGLIP_ONNX_SHA256) its sha256 matches the recorded value.
 # Build-arg pattern lets CI inject a pinned hash without rebuilding the
-# script. The script will exit non-zero (fail the build) if the URL is wrong
-# or the hash drifts — desired fail-loud behaviour.
+# script. The script exits non-zero ONCE SIGLIP_ONNX_SHA256 is set (then any
+# 404 / hash mismatch is a hard failure — desired fail-loud behaviour). When
+# the SHA is unset (current state, bucket pending provisioning), 404 logs a
+# warning and exits 0 so the rest of the deploy can proceed; the runtime
+# falls back to `EMBEDDINGS_PROVIDER=replicate`.
 ARG SIGLIP_ONNX_SHA256=""
 ENV SIGLIP_ONNX_SHA256=${SIGLIP_ONNX_SHA256}
 RUN bash scripts/fetch-models.sh

--- a/museum-backend/scripts/fetch-models.sh
+++ b/museum-backend/scripts/fetch-models.sh
@@ -22,13 +22,22 @@
 #                        until the bucket is provisioned and a canonical hash
 #                        is published; tracked in the T1.4 PARTIAL note).
 #
+# Bucket-not-provisioned tolerance (2026-05-10):
+#   When the URL returns 404 AND no SIGLIP_ONNX_SHA256 is configured, the
+#   script logs a warning and exits 0 instead of failing the Docker build.
+#   Rationale: the C3 visual-similarity feature has a managed fallback
+#   (`EMBEDDINGS_PROVIDER=replicate`) that doesn't need this artifact, and
+#   blocking every prod deploy until ops provisions the bucket would also
+#   block unrelated backend changes (RBAC fixes, security patches, etc.).
+#   Once SIGLIP_ONNX_SHA256 is set in CI/CD, ANY failure (404 or hash drift)
+#   becomes fail-loud again — the SHA being set is the explicit signal that
+#   the bucket is ready for production use.
+#
 # TODO(ops): provision the `musaium-models-public` GCS bucket and upload the
 # ONNX bundle exported via:
 #   optimum-cli export onnx --model google/siglip-base-patch16-224 ./models/siglip-base-patch16-224
 # Then publish the canonical SHA256 and propagate it to CI/CD secrets so this
-# script can refuse drift. Until then the URL below is a PLACEHOLDER and the
-# Docker build of museum-backend will fail at this step — which is the desired
-# fail-loud behaviour during the C3 staging window.
+# script can refuse drift.
 
 set -euo pipefail
 
@@ -65,8 +74,16 @@ echo "fetch-models: downloading $URL -> $DEST"
 if ! curl --fail --silent --show-error --location \
         --retry 3 --retry-all-errors --retry-delay 2 \
         --output "$PARTIAL" "$URL"; then
-  echo "fetch-models: download failed (URL=$URL)"
   rm -f "$PARTIAL"
+  if [ -z "$EXPECTED_SHA256" ]; then
+    # Bucket-not-provisioned tolerance — see header docstring. The runtime
+    # adapter selection (`EMBEDDINGS_PROVIDER`) controls whether siglip-onnx
+    # is attempted at all; without this artefact the `replicate` fallback
+    # remains usable.
+    echo "fetch-models: WARNING — download failed (URL=$URL) but no SIGLIP_ONNX_SHA256 set; skipping (bucket-not-provisioned tolerance)."
+    exit 0
+  fi
+  echo "fetch-models: download failed (URL=$URL)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

PR #255 merged successfully but its first push to main surfaced a deploy-prod failure that wasn't visible in PR CI (deploy-prod only runs on push to main):

\`\`\`
#17 [build 9/9] RUN bash scripts/fetch-models.sh
#17 0.064 fetch-models: downloading https://storage.googleapis.com/musaium-models-public/siglip-base-patch16-224.onnx -> ./models/siglip-base-patch16-224.onnx
#17 0.064 scripts/fetch-models.sh: line 65: curl: command not found
\`\`\`

Two compounding issues:
1. \`node:22-bookworm-slim\` ships without curl, but \`fetch-models.sh\` calls it.
2. The GCS bucket is still pending ops provisioning (returns 404). The script's own docstring acknowledges this: *"the URL below is a PLACEHOLDER and the Docker build of museum-backend will fail at this step — desired fail-loud behaviour during the C3 staging window."*

The fail-loud stance blocks **every** prod deploy until the bucket lands, including unrelated work (RBAC fix, security patches, etc.).

## Changes

- \`museum-backend/deploy/Dockerfile.prod\` — \`apt-get install curl ca-certificates\` in the build stage. C3 comment block updated to describe the graceful-skip semantics.
- \`museum-backend/scripts/fetch-models.sh\` — when the URL fails AND no \`SIGLIP_ONNX_SHA256\` is configured, log a WARNING and exit 0. Once ops sets the SHA in CI/CD, any failure (404 or hash drift) becomes fail-loud again — the SHA being set is the explicit "ready for prod" signal.

## Verification

Local test of the script (without changing the placeholder URL):

\`\`\`
# 404 + no SHA → graceful skip
$ bash scripts/fetch-models.sh
fetch-models: WARNING — download failed (URL=…) but no SIGLIP_ONNX_SHA256 set; skipping (bucket-not-provisioned tolerance).
EXIT=0

# 404 + SHA set → fail-loud preserved
$ SIGLIP_ONNX_SHA256=0000... bash scripts/fetch-models.sh
fetch-models: download failed (URL=…)
EXIT=1
\`\`\`

Runtime fallback: when the artefact is absent, \`EMBEDDINGS_PROVIDER=replicate\` handles \`/chat/compare\` without the local ONNX bundle (existing adapter, no change required).

## Test plan

- [ ] CI passes on PR
- [ ] Post-merge: \`ci-cd-backend.yml\` deploy-prod job goes green
- [ ] Post-deploy: prod backend boots (replicate adapter active for \`/chat/compare\`)
- [ ] super_admin can hit \`/api/admin/stats\` from \`/admin\` panel without 403 (the original RBAC fix in #255)

## Follow-up (ops)

Once the \`musaium-models-public\` GCS bucket is provisioned + the ONNX bundle uploaded + canonical SHA published:
1. Set \`SIGLIP_ONNX_SHA256\` as a CI secret + forward via \`build-args\` in \`ci-cd-backend.yml\`.
2. Switch \`EMBEDDINGS_PROVIDER\` env to \`siglip-onnx\` on the VPS \`.env\`.
3. fetch-models will then verify the SHA at build time, and the deploy fails loudly on drift — which is the original intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)