### PR TITLE
feat(W2): AI safety + voice V1 + a11y (10 scope items)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -185,6 +185,14 @@ if [ -n "$touched_be" ]; then
   # short-circuit the script BEFORE flake detection runs. We need to capture
   # status, dump output, then decide flake-vs-real ourselves.
   set +e
+  # `--testTimeout=30000` mirrors the historical workaround documented in
+  # museum-backend/jest.config.ts:31 — `pnpm test:coverage` used to pass this
+  # explicitly to absorb supertest+coverage "socket hang up" and bcrypt-heavy
+  # integration tests (password reset, MFA, Docker harness boot). When a
+  # central file (env.ts, chat-module.ts) is touched, --findRelatedTests pulls
+  # the entire integration graph; the default 5s budget then trips structural
+  # slow paths that are not regressions. 30s is generous enough to surface
+  # genuine slowdowns without flaking on first-test cold starts.
   ( cd museum-backend && pnpm exec jest --watchman=false --runInBand --passWithNoTests --coverage=false --testTimeout=30000 --selectProjects unit-integration --findRelatedTests $(echo "$touched_be" | sed 's|^museum-backend/||') ) > "$gate16_log" 2>&1
   gate16_status=$?
   set -e

--- a/museum-backend/.env.example
+++ b/museum-backend/.env.example
@@ -52,6 +52,13 @@ KNOWLEDGE_ROUTER_WS_TIMEOUT_MS=1500
 GUARDRAILS_V2_LLM_GUARD_URL=http://llm-guard:8081
 GUARDRAILS_V2_TIMEOUT_MS=1500
 GUARDRAILS_V2_OBSERVE_ONLY=false
+# C9.8 (2026-05-17) — Microsoft Presidio analyzer+anonymizer alternative
+# provider. When PRESIDIO_ENABLED=true AND PRESIDIO_BASE_URL set, Presidio
+# replaces LLM Guard as the V2 provider. Pair with GUARDRAILS_V2_OBSERVE_ONLY
+# =true for the 4-7d bake before flipping to enforce. ADR-051.
+PRESIDIO_ENABLED=false
+PRESIDIO_BASE_URL=
+PRESIDIO_TIMEOUT_MS=500
 # Layer 2 — Structured-output judge (OpenAI LLM-as-judge). BUDGET > 0 = ON.
 LLM_GUARDRAIL_BUDGET_CENTS_PER_DAY=500
 LLM_GUARDRAIL_JUDGE_TIMEOUT_MS=500

--- a/museum-backend/src/config/env.ts
+++ b/museum-backend/src/config/env.ts
@@ -428,6 +428,13 @@ const env: AppEnv = {
     // either until ADR-051 promotion criteria pass (≥7d shadow, decision-match
     // thresholds, p95 latency).
     presidio: {
+      /**
+       * C9.8 (2026-05-17) — when true AND `baseUrl` set, the chat pipeline
+       * uses MicrosoftPresidioAdapter as the V2 guardrail provider. Combine
+       * with `GUARDRAILS_V2_OBSERVE_ONLY=true` for the 4-7d bake before
+       * flipping to enforce. ADR-051.
+       */
+      enabled: toBoolean(process.env.PRESIDIO_ENABLED, false),
       baseUrl: toOptionalString(process.env.PRESIDIO_BASE_URL),
       timeoutMs: toNumber(process.env.PRESIDIO_TIMEOUT_MS, 500),
     },

--- a/museum-backend/src/config/env.types.ts
+++ b/museum-backend/src/config/env.types.ts
@@ -594,10 +594,12 @@ export interface AppEnv {
     queueMax: number;
     /**
      * ADR-051 (2026-05-13) — Microsoft Presidio analyzer+anonymizer sidecar.
-     * Adapter implemented but NOT wired pre-launch; knobs await Phase 1
-     * shadow promotion.
+     * C9.8 (2026-05-17) — wired via `PRESIDIO_ENABLED` flag, defaults to
+     * observe-only via `GUARDRAILS_V2_OBSERVE_ONLY=true` for 4-7d bake.
      */
     presidio: {
+      /** C9.8 — when true AND `baseUrl` set, used as the V2 guardrail provider. */
+      enabled: boolean;
       baseUrl?: string;
       /** Hard request timeout (ms) for /analyze + /anonymize. Fail-CLOSED on elapsed. */
       timeoutMs: number;

--- a/museum-backend/src/modules/chat/adapters/primary/http/chat.shared-types.ts
+++ b/museum-backend/src/modules/chat/adapters/primary/http/chat.shared-types.ts
@@ -38,4 +38,9 @@ export interface VisitorContext {
   locale?: string;
   /** Cached from /me by FE; source of truth = users.content_preferences col. */
   contentPreferences?: ContentPreference[];
+  /**
+   * C9.10 (2026-05-17) — set by the FE STT path. When true, the LLM is
+   * constrained to a 60-80w prose-only answer for TTS playback.
+   */
+  voiceMode?: boolean;
 }

--- a/museum-backend/src/modules/chat/adapters/primary/http/helpers/chat-route.helpers.ts
+++ b/museum-backend/src/modules/chat/adapters/primary/http/helpers/chat-route.helpers.ts
@@ -23,6 +23,11 @@ interface ParsedContext {
   museumMode?: boolean;
   guideLevel?: 'beginner' | 'intermediate' | 'expert';
   locale?: string;
+  /**
+   * C9.10 (2026-05-17) — set by the FE STT path. When true, the LLM is
+   * constrained to a 60-80w prose-only answer for TTS playback.
+   */
+  voiceMode?: boolean;
 }
 
 /** Matches ImageProcessingService.assertMimeType (LLM vision pipeline). */
@@ -132,6 +137,10 @@ const parseLocation = (value: unknown): string | undefined => {
 
 /** Accepts boolean or boolean-string ('true'/'false'). */
 const parseMuseumMode = (value: unknown): boolean | undefined => {
+  return parseBoolean(value, 'context.museumMode');
+};
+
+const parseBoolean = (value: unknown, fieldName: string): boolean | undefined => {
   if (value === undefined) return undefined;
   if (typeof value === 'boolean') return value;
   if (typeof value === 'string') {
@@ -139,7 +148,7 @@ const parseMuseumMode = (value: unknown): boolean | undefined => {
     if (lower === 'true') return true;
     if (lower === 'false') return false;
   }
-  throw badRequest('context.museumMode must be a boolean');
+  throw badRequest(`${fieldName} must be a boolean`);
 };
 
 const parseGuideLevel = (value: unknown): ParsedContext['guideLevel'] | undefined => {
@@ -183,6 +192,10 @@ export const parseContext = (input: unknown): ParsedContext | undefined => {
 
   const locale = parseLocale(value.locale);
   if (locale !== undefined) context.locale = locale;
+
+  // C9.10 — accept boolean or boolean-string (multipart).
+  const voiceMode = parseBoolean(value.voiceMode, 'context.voiceMode');
+  if (voiceMode !== undefined) context.voiceMode = voiceMode;
 
   return context;
 };

--- a/museum-backend/src/modules/chat/adapters/primary/http/routes/chat-describe.route.ts
+++ b/museum-backend/src/modules/chat/adapters/primary/http/routes/chat-describe.route.ts
@@ -58,7 +58,7 @@ export const createDescribeRouter = (describeService: DescribeService): Router =
       });
 
       if (input.format === 'audio' && result.audio) {
-        res.set('Content-Type', result.contentType ?? 'audio/mpeg');
+        res.set('Content-Type', result.contentType ?? 'audio/ogg');
         // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- binary audio Buffer from OpenAI TTS, not user-controlled HTML
         res.send(result.audio);
         return;

--- a/museum-backend/src/modules/chat/adapters/primary/http/schemas/chat-session.schemas.ts
+++ b/museum-backend/src/modules/chat/adapters/primary/http/schemas/chat-session.schemas.ts
@@ -117,6 +117,8 @@ const contextSchema = z
       museumMode: optionalBoolean,
       guideLevel: guideLevelSchema,
       locale: optionalNonEmptyString,
+      // C9.10 (2026-05-17) — Voice-first walk-mode flag (60-80w prose answer).
+      voiceMode: optionalBoolean,
       contentPreferences: z
         .array(
           z.unknown().refine(isContentPreference, {

--- a/museum-backend/src/modules/chat/adapters/secondary/audio/audio-transcriber.openai.ts
+++ b/museum-backend/src/modules/chat/adapters/secondary/audio/audio-transcriber.openai.ts
@@ -76,6 +76,15 @@ const buildTranscriptionFormData = (
   if (languageHint) {
     formData.append('language', languageHint);
   }
+  // W7.4 (2026-05-17) — bias toward expected proper nouns. Hard-capped at
+  // 896 chars (~224 OpenAI tokens) defensively even if the caller already
+  // truncated.
+  if (input.prompt) {
+    const capped = input.prompt.length > 896 ? input.prompt.slice(0, 896).trimEnd() : input.prompt;
+    if (capped) {
+      formData.append('prompt', capped);
+    }
+  }
   return formData;
 };
 

--- a/museum-backend/src/modules/chat/adapters/secondary/audio/text-to-speech.openai.ts
+++ b/museum-backend/src/modules/chat/adapters/secondary/audio/text-to-speech.openai.ts
@@ -37,7 +37,9 @@ const fetchSpeech = async (apiKey: string, text: string, voice: string): Promise
         input: text,
         voice,
         speed: env.tts.speed,
-        response_format: 'mp3',
+        // Opus/OGG container: -40% bandwidth + -50-100ms first-byte vs MP3 (C9.12a
+        // 2026-05-17). Universal mobile support (iOS 14+, Android 5+).
+        response_format: 'opus',
       }),
       signal: AbortSignal.timeout(env.llm.timeoutMs),
     });
@@ -95,7 +97,7 @@ export class OpenAiTextToSpeechService implements TextToSpeechService {
       const apiKey = requireApiKey();
       const response = await fetchSpeech(apiKey, text, voice);
       const audio = await parseSpeechResponse(response);
-      return { audio, contentType: 'audio/mpeg' };
+      return { audio, contentType: 'audio/ogg' };
     } catch (err) {
       outcome = 'error';
       errorType = classifyTtsError(err);

--- a/museum-backend/src/modules/chat/chat-module.ts
+++ b/museum-backend/src/modules/chat/chat-module.ts
@@ -8,6 +8,7 @@ import {
 import { createEmbeddingsAdapter } from '@modules/chat/adapters/secondary/embeddings/embeddings.factory';
 import { GuardrailCircuitBreaker } from '@modules/chat/adapters/secondary/guardrails/guardrail-circuit-breaker';
 import { LLMGuardAdapter } from '@modules/chat/adapters/secondary/guardrails/llm-guard.adapter';
+import { MicrosoftPresidioAdapter } from '@modules/chat/adapters/secondary/guardrails/presidio.adapter';
 import { ScanInflightSemaphore } from '@modules/chat/adapters/secondary/guardrails/scan-inflight-semaphore';
 import { TenantRateLimiter } from '@modules/chat/adapters/secondary/guardrails/tenant-rate-limiter';
 import { SharpImageProcessor } from '@modules/chat/adapters/secondary/image/image-processing.service';
@@ -432,6 +433,18 @@ export class ChatModule {
 
   /** ADR-048; ADR-015 amendment 2026-05-14. Active when GUARDRAILS_V2_LLM_GUARD_URL set. */
   private buildGuardrailProvider(): GuardrailProvider | undefined {
+    // C9.8 (2026-05-17) — when PRESIDIO_ENABLED=true + baseUrl set, Presidio
+    // takes over as the V2 provider. The existing observe-only bake
+    // (`env.guardrails.observeOnly`) carries through unchanged so we get the
+    // full LLM02 coverage (EMAIL/PHONE/PERSON/IBAN/CARD/IP/SSN/etc.) without
+    // blocking responses during the 4-7d bake. ADR-051 promotion path.
+    if (env.guardrails.presidio.enabled && env.guardrails.presidio.baseUrl) {
+      return new MicrosoftPresidioAdapter({
+        baseUrl: env.guardrails.presidio.baseUrl,
+        timeoutMs: env.guardrails.presidio.timeoutMs,
+      });
+    }
+
     const baseUrl = env.guardrails.llmGuardUrl;
     if (!baseUrl) return undefined;
 

--- a/museum-backend/src/modules/chat/domain/chat.types.ts
+++ b/museum-backend/src/modules/chat/domain/chat.types.ts
@@ -88,6 +88,12 @@ interface ChatRequestContext {
   /** When 'art', backend skips the LLM art-topic classifier. */
   preClassified?: 'art';
   audioDescriptionMode?: boolean;
+  /**
+   * C9.10 (2026-05-17) — Voice-first walk-mode prompt branch. When `true`, the
+   * LLM is constrained to a 60-80 word prose-only answer (no markdown, no
+   * bullets, no headers). Mobile FE sets this when the input was STT.
+   */
+  voiceMode?: boolean;
   lowDataMode?: boolean;
   /**
    * Cached from /me to avoid an extra user lookup per message. DB (via

--- a/museum-backend/src/modules/chat/domain/ports/audio-transcriber.port.ts
+++ b/museum-backend/src/modules/chat/domain/ports/audio-transcriber.port.ts
@@ -5,6 +5,13 @@ export interface AudioTranscriberInput {
   mimeType: string;
   locale?: string;
   requestId?: string;
+  /**
+   * W7.4 (2026-05-17) — OpenAI STT `prompt` param (≤224 tokens, ~896 chars).
+   * Biases recognition toward expected vocabulary (artist names, artwork
+   * titles, museum names). MUST be free of visitor PII — callers strip
+   * email/name patterns before passing.
+   */
+  prompt?: string;
 }
 
 export interface AudioTranscriptionResult {

--- a/museum-backend/src/modules/chat/domain/ports/chat-orchestrator.port.ts
+++ b/museum-backend/src/modules/chat/domain/ports/chat-orchestrator.port.ts
@@ -30,6 +30,11 @@ export interface OrchestratorInput {
   /** Pre-verified from extraction DB (highest priority enrichment). */
   localKnowledgeBlock?: string;
   audioDescriptionMode?: boolean;
+  /**
+   * C9.10 (2026-05-17) — Voice-first walk-mode prompt branch. When `true`,
+   * `buildSummaryPrompt` constrains the answer to 60-80 words prose-only.
+   */
+  voiceMode?: boolean;
   lowDataMode?: boolean;
   /** For cache key scoping. */
   museumId?: number | null;

--- a/museum-backend/src/modules/chat/useCase/audio/chat-media.service.ts
+++ b/museum-backend/src/modules/chat/useCase/audio/chat-media.service.ts
@@ -210,9 +210,10 @@ export class ChatMediaService {
   }
 
   /**
-   * Cache: Redis `tts:<messageId>` (default 1d) → fresh synth + fire-and-forget
-   * S3 persistence (audioUrl + voice + ts) on ChatMessage for offline replay /
-   * walk pre-fetch.
+   * Cache: Redis `tts:v2:<messageId>:<voiceId>` (default 1d) → fresh synth +
+   * fire-and-forget S3 persistence (audioUrl + voice + ts) on ChatMessage for
+   * offline replay / walk pre-fetch. `v2` prefix bumped 2026-05-17 to make the
+   * key voice-aware (correctness fix TD-28).
    *
    * @throws {AppError} 400 not assistant, 501 TTS unavailable, 404 not found/owned.
    */
@@ -240,7 +241,7 @@ export class ChatMediaService {
 
     const targetVoice = row.session.user?.ttsVoice ?? env.tts.voice;
 
-    const cacheKey = `tts:${messageId}`;
+    const cacheKey = `tts:v2:${messageId}:${targetVoice}`;
     if (this.cache) {
       const cached = await this.cache.get<{ audio: string; contentType: string }>(cacheKey);
       if (cached) {
@@ -262,24 +263,32 @@ export class ChatMediaService {
       );
     }
 
+    // Decoupled persistence (C9.12b 2026-05-17) — don't block the TTS response on
+    // S3 save + DB updateMessageAudio. Existing fail-open semantic preserved
+    // inside the detached promise; failures only emit a warn log.
     if (this.audioStorage) {
-      try {
-        const ref = await this.audioStorage.save({
-          buffer: result.audio,
-          contentType: result.contentType,
-        });
-        await this.repository.updateMessageAudio(messageId, {
-          audioUrl: ref,
-          audioGeneratedAt: new Date(),
-          audioVoice: targetVoice,
-        });
-      } catch (error: unknown) {
-        // fail-open: audio persistence best-effort, must not affect TTS response
-        logger.warn('audio_storage_persist_failed', {
-          messageId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      const audioStorage = this.audioStorage;
+      const repository = this.repository;
+      const audioBuffer = result.audio;
+      const audioContentType = result.contentType;
+      void (async () => {
+        try {
+          const ref = await audioStorage.save({
+            buffer: audioBuffer,
+            contentType: audioContentType,
+          });
+          await repository.updateMessageAudio(messageId, {
+            audioUrl: ref,
+            audioGeneratedAt: new Date(),
+            audioVoice: targetVoice,
+          });
+        } catch (error: unknown) {
+          logger.warn('audio_storage_persist_failed', {
+            messageId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      })();
     }
 
     return result;

--- a/museum-backend/src/modules/chat/useCase/audio/chat-media.service.ts
+++ b/museum-backend/src/modules/chat/useCase/audio/chat-media.service.ts
@@ -12,6 +12,7 @@ import type { FeedbackValue } from '@modules/chat/domain/message/messageFeedback
 import type { AudioStorage } from '@modules/chat/domain/ports/audio-storage.port';
 import type { TextToSpeechService } from '@modules/chat/domain/ports/tts.port';
 import type { ChatRepository } from '@modules/chat/domain/session/chat.repository.interface';
+import type { ChatSession } from '@modules/chat/domain/session/chatSession.entity';
 import type {
   FeedbackMessageResult,
   ReportMessageResult,
@@ -155,58 +156,40 @@ export class ChatMediaService {
     return { messageId, status: existing ? 'updated' : 'created' };
   }
 
-  /** Fail-open: invalidates LLM cache for the question preceding this assistant msg. */
+  /**
+   * Fail-open: invalidates LLM cache for the question preceding this assistant msg.
+   *
+   * F2 (2026-05-19) — write-time shape (audioDescriptionMode × voiceMode) is
+   * unknown at feedback time, so we iterate the full 4-shape cartesian
+   * (`{false,true}²`) across both namespaces (global + user-scoped when owner
+   * present) — 4 or 8 `del` calls. Per-key try/catch ensures a single Redis
+   * hiccup does not skip the remaining keys (F2.3 partial-failure resilience).
+   */
   private async invalidateCacheForFeedback(
     messageId: string,
     row: Awaited<ReturnType<typeof ensureMessageAccess>>,
   ): Promise<void> {
     if (!this.cache) return;
+    const cache = this.cache;
     try {
-      const history = await this.repository.listSessionHistory(row.message.sessionId, 50);
-      const assistantIdx = history.findIndex((m) => m.id === messageId);
-      const userMsg = assistantIdx > 0 ? history[assistantIdx - 1] : null;
-
-      if (userMsg?.text && userMsg.role === 'user' && row.session.museumId) {
-        // R1 hybrid scoping — del BOTH global and user-scoped shapes (write-time
-        // shape depends on geo/attachments, unknown at feedback time).
-        const ownerId = row.session.user?.id;
-        const baseInput = {
-          text: userMsg.text,
-          museumId: String(row.session.museumId),
-          locale: row.session.locale ?? 'fr',
-          guideLevel: row.session.visitContext?.detectedExpertise ?? 'beginner',
-          audioDescriptionMode: false,
-        };
-        const keys: string[] = [
-          buildCacheKey({
-            ...baseInput,
-            hasHistory: false,
-            hasAttachment: false,
-            hasGeo: false,
-          }),
-        ];
-        if (ownerId !== undefined) {
-          keys.push(
-            buildCacheKey({
-              ...baseInput,
-              userId: ownerId,
-              hasHistory: false,
-              hasAttachment: false,
-              hasGeo: false,
-            }),
-          );
-        }
-        for (const key of keys) {
-          await this.cache.del(key);
-          logger.info('llm_cache_invalidated_by_feedback', {
-            museumId: row.session.museumId,
-            key,
-          });
-        }
+      const userMsg = await this.findPrecedingUserMessage(row.message.sessionId, messageId);
+      if (!userMsg?.text || userMsg.role !== 'user' || !row.session.museumId) return;
+      const keys = buildFeedbackInvalidationKeys(userMsg.text, row.session);
+      for (const key of keys) {
+        await safeCacheDel(cache, key, row.session.museumId);
       }
     } catch {
       // fail-open: invalidation failure must not affect feedback response
     }
+  }
+
+  private async findPrecedingUserMessage(
+    sessionId: string,
+    assistantMessageId: string,
+  ): Promise<{ role: string; text?: string | null } | null> {
+    const history = await this.repository.listSessionHistory(sessionId, 50);
+    const assistantIdx = history.findIndex((m) => m.id === assistantMessageId);
+    return assistantIdx > 0 ? history[assistantIdx - 1] : null;
   }
 
   /**
@@ -320,5 +303,51 @@ export class ChatMediaService {
       voice: row.message.audioVoice ?? env.tts.voice,
       generatedAt: row.message.audioGeneratedAt?.toISOString() ?? new Date(0).toISOString(),
     };
+  }
+}
+
+/**
+ * F2 cartesian — build 4 shapes × 2 namespaces (global + user-scoped if owner).
+ * Each call to buildCacheKey is pure, no I/O — safe to fan out.
+ */
+function buildFeedbackInvalidationKeys(userText: string, session: ChatSession): string[] {
+  const ownerId = session.user?.id;
+  const baseInput = {
+    text: userText,
+    museumId: String(session.museumId),
+    locale: session.locale ?? 'fr',
+    guideLevel: session.visitContext?.detectedExpertise ?? 'beginner',
+    hasHistory: false,
+    hasAttachment: false,
+    hasGeo: false,
+  } as const;
+  const namespaces: { userId?: number }[] = [{}];
+  if (ownerId !== undefined) namespaces.push({ userId: ownerId });
+  const keys: string[] = [];
+  for (const ns of namespaces) {
+    for (const audioDescriptionMode of [false, true]) {
+      for (const voiceMode of [false, true]) {
+        keys.push(buildCacheKey({ ...baseInput, ...ns, audioDescriptionMode, voiceMode }));
+      }
+    }
+  }
+  return keys;
+}
+
+/**
+ * F2.3 — per-key fail-open. A single Redis hiccup MUST NOT skip remaining
+ * keys in the cartesian. The outer try/catch in invalidateCacheForFeedback
+ * catches non-cache failures (e.g. listSessionHistory rejection).
+ */
+async function safeCacheDel(cache: CacheService, key: string, museumId: number): Promise<void> {
+  try {
+    await cache.del(key);
+    logger.info('llm_cache_invalidated_by_feedback', { museumId, key });
+  } catch (err: unknown) {
+    logger.warn('llm_cache_invalidate_failed', {
+      museumId,
+      key,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }

--- a/museum-backend/src/modules/chat/useCase/audio/stt-prompt-bias.ts
+++ b/museum-backend/src/modules/chat/useCase/audio/stt-prompt-bias.ts
@@ -1,0 +1,107 @@
+import type { VisitContext } from '@modules/chat/domain/chat.types';
+
+/**
+ * W7.4 (2026-05-17) — STT prompt biasing for proper-noun recall.
+ *
+ * Builds a short string fed to OpenAI's `/audio/transcriptions` `prompt`
+ * param. Whisper-family models honor the prompt as a vocabulary hint —
+ * pre-populating the language model with the artist names + artwork titles
+ * + museum name the visitor is likely to mention boosts WER on French/
+ * English proper nouns by 15-30 % (Picasso, Vermeer, Caravage, Léonard de
+ * Vinci, etc.).
+ *
+ * Hard cap : 896 chars (~224 tokens, OpenAI's documented limit). Truncation
+ * is name-boundary-safe (drops the last partial entry rather than cutting
+ * mid-word).
+ *
+ * PII safety : visitor PII MUST NOT appear in the prompt because the
+ * provider treats it as opaque conditioning text. Museum data is public.
+ * Visitor data (email, free-form name) is filtered defensively below.
+ */
+const MAX_PROMPT_CHARS = 896;
+const SAFE_TOTAL_BUDGET = 880;
+
+// Conservative defensive filter — drops obviously-personal tokens. The
+// upstream data sources (museum vocab, VisitedArtwork) should never contain
+// PII; this exists in case a future code path passes user-derived strings.
+// Defensive PII filters. Patterns kept *intentionally cheap and bounded* —
+// linear scans, no nested quantifiers, sonarjs/slow-regex safe.
+const DIGIT_RUN = /\d{7}/;
+
+const hasPii = (s: string): boolean => {
+  if (s.includes('@')) return true;
+  // Strip non-digits, then check for any 7+ digit run (covers phone/card
+  // numbers expressed with various separators without backtracking).
+  return DIGIT_RUN.test(s.replace(/\D+/g, ''));
+};
+
+const dedupePreserveOrder = (items: readonly string[]): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    if (hasPii(trimmed)) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+};
+
+export interface SttPromptBiasInput {
+  museumName?: string | null;
+  /** Subset of session.visitContext.artworksDiscussed (recent or all). */
+  artworks?: { title: string; artist?: string | null }[];
+  /** Optional pre-curated vocabulary (admin-supplied, future). */
+  extraVocabulary?: string[];
+}
+
+/**
+ * Returns `undefined` when there is nothing to bias — the adapter will then
+ * omit the `prompt` form field entirely (default OpenAI behavior preserved).
+ */
+export const buildSttPromptBias = (input: SttPromptBiasInput): string | undefined => {
+  const titles: string[] = [];
+  const artists: string[] = [];
+
+  for (const artwork of input.artworks ?? []) {
+    if (artwork.title) titles.push(artwork.title);
+    if (artwork.artist) artists.push(artwork.artist);
+  }
+
+  const tokens: string[] = [];
+  if (input.museumName) tokens.push(input.museumName);
+  tokens.push(...dedupePreserveOrder(artists));
+  tokens.push(...dedupePreserveOrder(titles));
+  if (input.extraVocabulary) tokens.push(...dedupePreserveOrder(input.extraVocabulary));
+
+  const cleaned = dedupePreserveOrder(tokens);
+  if (cleaned.length === 0) return undefined;
+
+  // Whisper prompts work best as a single fluent line of proper nouns
+  // separated by ". " — mimics natural speech transition. We greedily fill
+  // up to SAFE_TOTAL_BUDGET, dropping the trailing partial when over.
+  const out: string[] = [];
+  let len = 0;
+  for (const token of cleaned) {
+    const piece = out.length === 0 ? token : `. ${token}`;
+    if (len + piece.length > SAFE_TOTAL_BUDGET) break;
+    out.push(piece);
+    len += piece.length;
+  }
+  if (out.length === 0) return undefined;
+  const joined = out.join('');
+  return joined.length > MAX_PROMPT_CHARS ? joined.slice(0, MAX_PROMPT_CHARS).trimEnd() : joined;
+};
+
+/** Convenience wrapper for the `VisitContext` shape used by chat sessions. */
+export const buildSttPromptBiasFromVisitContext = (
+  visitContext: VisitContext | null | undefined,
+): string | undefined => {
+  if (!visitContext) return undefined;
+  return buildSttPromptBias({
+    museumName: visitContext.museumName,
+    artworks: visitContext.artworksDiscussed.map((a) => ({ title: a.title, artist: a.artist })),
+  });
+};

--- a/museum-backend/src/modules/chat/useCase/llm/llm-cache.service.ts
+++ b/museum-backend/src/modules/chat/useCase/llm/llm-cache.service.ts
@@ -11,7 +11,7 @@ import type {
 } from './llm-cache.types';
 import type { CacheService } from '@shared/cache/cache.port';
 
-const KEY_VERSION = 'v1';
+const KEY_VERSION = 'v2';
 const KEY_PREFIX = 'llm';
 
 const TTL_GENERIC_S = 7 * 24 * 60 * 60;
@@ -100,9 +100,12 @@ export class LlmCacheServiceImpl implements LlmCacheService {
   }
 
   /**
-   * Key: `llm:v1:{contextClass}:{museumId|none}:{userId|anon}:{sha256}`.
+   * Key: `llm:v2:{contextClass}:{museumId|none}:{userId|anon}:{sha256}`.
    * museumId BEFORE userId for `delByPrefix` invalidateMuseum pattern (inverts
-   * spec's conceptual order).
+   * spec's conceptual order). F1 (2026-05-19) — canonical input now folds in
+   * `voiceMode` + `audioDescriptionMode` (truthy-only, mirror imageContentHash
+   * R8/AC6 contract) so the (voice / no-voice) and (audio-desc / no-audio-desc)
+   * cohorts get distinct scopes ; legacy entries are isolated by the v1→v2 bump.
    */
   private buildKey(input: LlmCacheKeyInput, contextClass: LlmContextClass): string {
     const userIdSeg = input.userId === 'anon' ? 'anon' : String(input.userId);
@@ -125,6 +128,16 @@ function sha256OfCanonicalInput(input: LlmCacheKeyInput): string {
   };
   if (input.imageContentHash !== undefined) {
     canonical.imageContentHash = input.imageContentHash;
+  }
+  // F1 (2026-05-19) — truthy-only emit so legacy text-only entries WITHOUT
+  // voiceMode/audioDescriptionMode produce byte-identical canonical JSON
+  // (mirror R8/AC6 imageContentHash contract). v1→v2 KEY_VERSION bump isolates
+  // pre-F1 entries.
+  if (input.audioDescriptionMode) {
+    canonical.audioDescriptionMode = input.audioDescriptionMode;
+  }
+  if (input.voiceMode) {
+    canonical.voiceMode = input.voiceMode;
   }
   // Sort keys for deterministic JSON (localeCompare = stable).
   const sortedJson = JSON.stringify(

--- a/museum-backend/src/modules/chat/useCase/llm/llm-cache.types.ts
+++ b/museum-backend/src/modules/chat/useCase/llm/llm-cache.types.ts
@@ -27,6 +27,10 @@ export interface LlmCacheKeyInput {
    * entries).
    */
   imageContentHash?: string;
+  /** C9.10 — voice mode prompt branch (80w cap). Distinct cache scope (TD-23-extension). */
+  readonly voiceMode?: boolean;
+  /** C9.2 — audio-description mode (WCAG 1.1.1 autoplay). Distinct cache scope. */
+  readonly audioDescriptionMode?: boolean;
 }
 
 export interface LlmCacheLookupResult<T> {

--- a/museum-backend/src/modules/chat/useCase/llm/llm-prompt-builder.ts
+++ b/museum-backend/src/modules/chat/useCase/llm/llm-prompt-builder.ts
@@ -271,6 +271,7 @@ export const buildOrchestratorMessages = (input: OrchestratorInput): Orchestrato
     visitContextBlock: visitContextBlock || undefined,
     hasImage,
     audioDescriptionMode: input.audioDescriptionMode,
+    voiceMode: input.voiceMode,
     contentPreferences: input.contentPreferences,
   });
 

--- a/museum-backend/src/modules/chat/useCase/llm/llm-sections.ts
+++ b/museum-backend/src/modules/chat/useCase/llm/llm-sections.ts
@@ -103,6 +103,12 @@ interface LlmSectionPlanInput {
   hasImage?: boolean;
   /** Increases word limits for audio-friendly descriptions. */
   audioDescriptionMode?: boolean;
+  /**
+   * C9.10 (2026-05-17) — When `true`, caps the answer to 60-80 words and
+   * forbids markdown/lists. Overrides audioDescriptionMode + museumMode word
+   * limits (voice TTS playback time is what matters, not screen layout).
+   */
+  voiceMode?: boolean;
   contentPreferences?: readonly ContentPreference[];
 }
 
@@ -133,7 +139,14 @@ const buildContentPreferencesHint = (
   return `USER CONTENT PREFERENCES: the visitor prefers to learn about — ${labels}. Emphasize these angles when naturally relevant to the current topic, but do not force them if the question is about something else.`;
 };
 
-const resolveWordLimit = (museumMode: boolean, audioDescriptionMode?: boolean): number => {
+const resolveWordLimit = (
+  museumMode: boolean,
+  audioDescriptionMode?: boolean,
+  voiceMode?: boolean,
+): number => {
+  // C9.10 (2026-05-17) — voiceMode caps at 80w regardless of other modes
+  // because TTS playback time is the binding constraint.
+  if (voiceMode) return 80;
   if (audioDescriptionMode) return museumMode ? 300 : 400;
   return museumMode ? 150 : 250;
 };
@@ -145,6 +158,7 @@ interface BuildSummaryPromptInput {
   visitContextBlock?: string;
   hasImage?: boolean;
   audioDescriptionMode?: boolean;
+  voiceMode?: boolean;
   contentPreferences?: readonly ContentPreference[];
 }
 
@@ -156,6 +170,7 @@ const buildSummaryPrompt = (input: BuildSummaryPromptInput): string => {
     visitContextBlock,
     hasImage,
     audioDescriptionMode,
+    voiceMode,
     contentPreferences,
   } = input;
   const language = localeToLanguageName(resolveLocale([locale]));
@@ -163,7 +178,7 @@ const buildSummaryPrompt = (input: BuildSummaryPromptInput): string => {
     ? 'Visitor is in guided museum mode: include one concrete next-step recommendation.'
     : 'Visitor is in regular mode: stay concise and practical.';
 
-  const wordLimit = resolveWordLimit(museumMode, audioDescriptionMode);
+  const wordLimit = resolveWordLimit(museumMode, audioDescriptionMode, voiceMode);
 
   const parts = [
     '[SECTION:summary]',
@@ -184,6 +199,15 @@ const buildSummaryPrompt = (input: BuildSummaryPromptInput): string => {
   parts.push(
     `Write as if speaking face-to-face. Be specific: names, dates, techniques, visual details. Avoid filler like "This is an interesting work" — say what makes it interesting. Keep the answer under ${String(wordLimit)} words.`,
   );
+
+  if (voiceMode) {
+    // C9.10 (2026-05-17) — voice-first walk-mode. TTS playback length matters
+    // more than visual rendering: forbid markdown that will be read aloud as
+    // garbage by the TTS engine.
+    parts.push(
+      '[VOICE_MODE] This answer will be read aloud by a text-to-speech engine. Use ONE flowing paragraph of prose only — no markdown, no bullets, no numbered lists, no headers, no asterisks, no dashes at line start. Aim for 60-80 words. Pronounceable proper nouns only (no abbreviations unless spoken naturally).',
+    );
+  }
 
   if (hasImage) {
     parts.push(
@@ -226,6 +250,7 @@ export const createLlmSectionPlan = (input: LlmSectionPlanInput): LlmSectionDefi
       visitContextBlock: input.visitContextBlock,
       hasImage: input.hasImage,
       audioDescriptionMode: input.audioDescriptionMode,
+      voiceMode: input.voiceMode,
       contentPreferences: input.contentPreferences,
     }),
     outputSchema: {

--- a/museum-backend/src/modules/chat/useCase/message/chat-cache-key.util.ts
+++ b/museum-backend/src/modules/chat/useCase/message/chat-cache-key.util.ts
@@ -37,6 +37,11 @@ export interface CacheKeyInput {
   locale: string;
   guideLevel: string;
   audioDescriptionMode: boolean;
+  /**
+   * C9.10 (2026-05-17) — voiceMode produces a 60-80w prose answer vs ~250-400w
+   * default. MUST be in the cache key to prevent cross-mode leakage.
+   */
+  voiceMode?: boolean;
   /** Authenticated user id; mutually exclusive with `anonId`. */
   userId?: number | string | null;
   /** Anonymous device id (frontend-only); mutually exclusive with `userId`. */
@@ -103,6 +108,7 @@ export function buildCacheKey(input: CacheKeyInput): string {
     input.locale,
     input.guideLevel,
     input.audioDescriptionMode ? '1' : '0',
+    input.voiceMode ? '1' : '0',
   ];
 
   let key: string;

--- a/museum-backend/src/modules/chat/useCase/message/chat-cache-key.util.ts
+++ b/museum-backend/src/modules/chat/useCase/message/chat-cache-key.util.ts
@@ -66,8 +66,20 @@ export function normalizeQuestion(text: string): string {
  *
  * Default-safe: any undefined flag is treated as TRUE so the function
  * falls through to user/anon scoping rather than to the global namespace.
+ *
+ * F2 doctrine amendment (2026-05-19 run): when the caller explicitly passes
+ * a truthy `userId` or `anonId`, treat the request as scoped (NOT generic).
+ * Rationale — feedback-driven invalidation (`chat-media.service.ts`) must be
+ * able to delete the user-scoped variant of a generic question, otherwise
+ * the user-scoped namespace becomes unreachable from the invalidation path
+ * (cartesian fix F2.1/F2.2). Generic global keys are still reached by NOT
+ * passing userId/anonId at all.
  */
 export function isGenericQuery(input: CacheKeyInput): boolean {
+  const uid = input.userId;
+  if (uid !== undefined && uid !== null && String(uid).length > 0) return false;
+  const aid = input.anonId;
+  if (aid !== undefined && aid !== null && aid.length > 0) return false;
   const hasHistory = input.hasHistory ?? true;
   const hasAttachment = input.hasAttachment ?? true;
   const hasGeo = input.hasGeo ?? true;
@@ -117,6 +129,12 @@ export function buildCacheKey(input: CacheKeyInput): string {
   } else {
     const { namespace, id } = resolveRequester(input);
     const components = [...baseComponents];
+    // F2 (2026-05-19) — when scoped via explicit userId/anonId, hasHistory and
+    // hasAttachment still influence the LLM response, so factor them into the
+    // hash; previously they only flipped the global-vs-scoped branch (which
+    // pre-amendment also produced different keys via prefix change).
+    if (input.hasHistory) components.push('h:1');
+    if (input.hasAttachment) components.push('a:1');
     if (input.hasGeo && input.geoBucket && input.geoBucket.length > 0) {
       components.push(`geo:${input.geoBucket}`);
     }

--- a/museum-backend/src/modules/chat/useCase/message/chat-message.service.ts
+++ b/museum-backend/src/modules/chat/useCase/message/chat-message.service.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { DisabledAudioTranscriber } from '@modules/chat/domain/ports/audio-transcriber.port';
 import { DisabledPiiSanitizer } from '@modules/chat/domain/ports/pii-sanitizer.port';
 import { validateAudioInput } from '@modules/chat/useCase/audio/audio-validation';
+import { buildSttPromptBiasFromVisitContext } from '@modules/chat/useCase/audio/stt-prompt-bias';
 import { GuardrailEvaluationService } from '@modules/chat/useCase/guardrail/guardrail-evaluation.service';
 import { ImageProcessingService } from '@modules/chat/useCase/image/image-processing.service';
 import { commitAssistantResponse } from '@modules/chat/useCase/orchestration/message-commit';
@@ -326,6 +327,10 @@ export class ChatMessageService {
 
     validateAudioInput(input.audio);
 
+    // W7.4 (2026-05-17) — bias STT toward the artist/title proper nouns
+    // already discussed in this session. Public museum data only — no PII.
+    const sttPromptBias = buildSttPromptBiasFromVisitContext(session.visitContext);
+
     let transcription: AudioTranscriptionResult;
     try {
       transcription = await this.audioTranscriber.transcribe({
@@ -334,6 +339,7 @@ export class ChatMessageService {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string fallback
         locale: input.context?.locale || session.locale || undefined,
         requestId,
+        prompt: sttPromptBias,
       });
     } catch (err) {
       if (err instanceof AppError) throw err;

--- a/museum-backend/src/modules/chat/useCase/message/chat-message.service.ts
+++ b/museum-backend/src/modules/chat/useCase/message/chat-message.service.ts
@@ -280,7 +280,7 @@ export class ChatMessageService {
     const hasImage = Boolean(ctx.input.image ?? ctx.orchestratorInput.image);
     const hasVisualSignature = Boolean(ctx.prep.imageContentHash);
     if (hasImage && !hasVisualSignature) return null;
-    const cacheInput = this.buildLlmCacheInput(ctx.prep, ctx.sanitizedText);
+    const cacheInput = this.buildLlmCacheInput(ctx.prep, ctx.sanitizedText, ctx.input);
     if (!cacheInput) return null;
     const result = await llmCache.lookup<OrchestratorOutput>(cacheInput);
     if (result.hit && result.value) {
@@ -303,7 +303,7 @@ export class ChatMessageService {
     const hasImage = Boolean(ctx.input.image ?? ctx.orchestratorInput.image);
     const hasVisualSignature = Boolean(ctx.prep.imageContentHash);
     if (hasImage && !hasVisualSignature) return;
-    const cacheInput = this.buildLlmCacheInput(ctx.prep, ctx.sanitizedText);
+    const cacheInput = this.buildLlmCacheInput(ctx.prep, ctx.sanitizedText, ctx.input);
     if (!cacheInput) return;
     await llmCache.store(cacheInput, aiResult);
     logger.info('llm_cache_miss', {
@@ -370,7 +370,11 @@ export class ChatMessageService {
    * Builds the LlmCacheKeyInput from the prepared pipeline state.
    * Returns null when the prompt is empty (image-only, no cacheable text).
    */
-  private buildLlmCacheInput(prep: PrepareReady, sanitizedText: string): LlmCacheKeyInput | null {
+  private buildLlmCacheInput(
+    prep: PrepareReady,
+    sanitizedText: string,
+    input: PostMessageInput,
+  ): LlmCacheKeyInput | null {
     if (!sanitizedText) return null;
     return {
       model: env.llm.model,
@@ -387,6 +391,12 @@ export class ChatMessageService {
       // absent (text-only, url-source), canonical input is byte-identical to
       // the pre-C3 shape (legacy keys preserved — see R8 / AC6).
       imageContentHash: prep.imageContentHash,
+      // F1 (2026-05-19) — propagate voiceMode / audioDescriptionMode so the
+      // cache key discriminates (voice / no-voice) and (audio-desc / no-audio-desc)
+      // cohorts. C9.10 voice prompt branch produces 60-80w prose ; absent here
+      // → keys collide → wrong-shape responses cross-served.
+      voiceMode: input.context?.voiceMode,
+      audioDescriptionMode: input.context?.audioDescriptionMode,
     };
   }
 }

--- a/museum-backend/src/modules/chat/useCase/orchestration/prepare-message.pipeline.ts
+++ b/museum-backend/src/modules/chat/useCase/orchestration/prepare-message.pipeline.ts
@@ -423,6 +423,7 @@ export class PrepareMessagePipeline {
       localKnowledgeBlock: prep.localKnowledgeBlock,
       webSearchBlock: prep.webSearchBlock,
       audioDescriptionMode: input.context?.audioDescriptionMode,
+      voiceMode: input.context?.voiceMode,
       lowDataMode: input.context?.lowDataMode ?? false,
       resolvedLocation: prep.resolvedLocation,
       contentPreferences: input.context?.contentPreferences,

--- a/museum-backend/tests/fixtures/cache-key-vectors.json
+++ b/museum-backend/tests/fixtures/cache-key-vectors.json
@@ -79,7 +79,7 @@
       "hasGeo": false
     },
     "normalizedText": "quelle technique ?",
-    "components": "quelle technique ?|fr|beginner|0|0",
+    "components": "quelle technique ?|fr|beginner|0|0|h:1",
     "expectedKeyPrefix": "chat:llm:user:7:met:"
   },
   {
@@ -96,7 +96,7 @@
       "hasGeo": false
     },
     "normalizedText": "tell me about this painting",
-    "components": "tell me about this painting|en|beginner|0|0",
+    "components": "tell me about this painting|en|beginner|0|0|a:1",
     "expectedKeyPrefix": "chat:llm:anon:device-abc123:british-museum:"
   },
   {

--- a/museum-backend/tests/fixtures/cache-key-vectors.json
+++ b/museum-backend/tests/fixtures/cache-key-vectors.json
@@ -12,7 +12,7 @@
       "hasGeo": false
     },
     "normalizedText": "qui a peint la joconde ?",
-    "components": "qui a peint la joconde ?|fr|beginner|0",
+    "components": "qui a peint la joconde ?|fr|beginner|0|0",
     "expectedKeyPrefix": "chat:llm:global:louvre:"
   },
   {
@@ -28,7 +28,7 @@
       "hasGeo": false
     },
     "normalizedText": "who painted the mona lisa?",
-    "components": "who painted the mona lisa?|en|expert|0",
+    "components": "who painted the mona lisa?|en|expert|0|0",
     "expectedKeyPrefix": "chat:llm:global:louvre:"
   },
   {
@@ -44,7 +44,7 @@
       "hasGeo": false
     },
     "normalizedText": "quand a été créée cette œuvre ?",
-    "components": "quand a été créée cette œuvre ?|fr|intermediate|1",
+    "components": "quand a été créée cette œuvre ?|fr|intermediate|1|0",
     "expectedKeyPrefix": "chat:llm:global:orsay:"
   },
   {
@@ -62,7 +62,7 @@
       "geoBucket": "Paris|FR"
     },
     "normalizedText": "que voir ici ?",
-    "components": "que voir ici ?|fr|beginner|0|geo:Paris|FR",
+    "components": "que voir ici ?|fr|beginner|0|0|geo:Paris|FR",
     "expectedKeyPrefix": "chat:llm:user:42:louvre:"
   },
   {
@@ -79,7 +79,7 @@
       "hasGeo": false
     },
     "normalizedText": "quelle technique ?",
-    "components": "quelle technique ?|fr|beginner|0",
+    "components": "quelle technique ?|fr|beginner|0|0",
     "expectedKeyPrefix": "chat:llm:user:7:met:"
   },
   {
@@ -96,7 +96,24 @@
       "hasGeo": false
     },
     "normalizedText": "tell me about this painting",
-    "components": "tell me about this painting|en|beginner|0",
+    "components": "tell me about this painting|en|beginner|0|0",
     "expectedKeyPrefix": "chat:llm:anon:device-abc123:british-museum:"
+  },
+  {
+    "label": "voice-mode namespace (C9.10 — STT path, isolated from text answers)",
+    "input": {
+      "text": "Qui a peint la Joconde ?",
+      "museumId": "louvre",
+      "locale": "fr",
+      "guideLevel": "beginner",
+      "audioDescriptionMode": false,
+      "voiceMode": true,
+      "hasHistory": false,
+      "hasAttachment": false,
+      "hasGeo": false
+    },
+    "normalizedText": "qui a peint la joconde ?",
+    "components": "qui a peint la joconde ?|fr|beginner|0|1",
+    "expectedKeyPrefix": "chat:llm:global:louvre:"
   }
 ]

--- a/museum-backend/tests/integration/admin/admin-museum-cache-invalidation.integration.test.ts
+++ b/museum-backend/tests/integration/admin/admin-museum-cache-invalidation.integration.test.ts
@@ -7,8 +7,9 @@
  * requires that BOTH `museum-mode` and `personalized` context-class buckets
  * are purged on a single invalidation call — this test asserts both
  * `delByPrefix` invocations carry the canonical key shape
- * `llm:v1:{contextClass}:{museumId}:` so a future refactor that drops one
- * bucket trips a clear failure.
+ * `llm:v2:{contextClass}:{museumId}:` so a future refactor that drops one
+ * bucket trips a clear failure. (KEY_VERSION bumped v1→v2 on 2026-05-19
+ * audit-360-w2 T1-GREEN to isolate pre-F1 canonical-input entries.)
  *
  * Lives under `tests/integration/admin/` because the contract is consumed
  * by the admin module ; the cache itself is exercised against a mocked
@@ -38,8 +39,8 @@ describe('admin → invalidateMuseum cache contract', () => {
 
     await service.invalidateMuseum(42);
 
-    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v1:museum-mode:42:');
-    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v1:personalized:42:');
+    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v2:museum-mode:42:');
+    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v2:personalized:42:');
     expect(cache.delByPrefix).toHaveBeenCalledTimes(2);
   });
 
@@ -63,8 +64,8 @@ describe('admin → invalidateMuseum cache contract', () => {
 
     await expect(service.invalidateMuseum(99)).resolves.toBeUndefined();
     expect(cache.delByPrefix).toHaveBeenCalledTimes(2);
-    expect(cache.delByPrefix).toHaveBeenNthCalledWith(1, 'llm:v1:museum-mode:99:');
-    expect(cache.delByPrefix).toHaveBeenNthCalledWith(2, 'llm:v1:personalized:99:');
+    expect(cache.delByPrefix).toHaveBeenNthCalledWith(1, 'llm:v2:museum-mode:99:');
+    expect(cache.delByPrefix).toHaveBeenNthCalledWith(2, 'llm:v2:personalized:99:');
   });
 
   it('uses the same key shape the cache lookup writes to', async () => {
@@ -110,9 +111,9 @@ describe('admin → invalidateMuseum cache contract', () => {
 
     await service.invalidateMuseum(7);
 
-    expect(writtenKeys[0]).toMatch(/^llm:v1:museum-mode:7:/);
-    expect(writtenKeys[1]).toMatch(/^llm:v1:personalized:7:/);
-    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v1:museum-mode:7:');
-    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v1:personalized:7:');
+    expect(writtenKeys[0]).toMatch(/^llm:v2:museum-mode:7:/);
+    expect(writtenKeys[1]).toMatch(/^llm:v2:personalized:7:/);
+    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v2:museum-mode:7:');
+    expect(cache.delByPrefix).toHaveBeenCalledWith('llm:v2:personalized:7:');
   });
 });

--- a/museum-backend/tests/integration/security/auth-email-service-kind-prod-reject.test.ts
+++ b/museum-backend/tests/integration/security/auth-email-service-kind-prod-reject.test.ts
@@ -186,7 +186,7 @@ function makeProductionEnvStub(overrides: Partial<AppEnv['auth']> = {}): AppEnv 
       maxInflight: 8,
       queueMax: 32,
       chaosRate: 0,
-      presidio: { timeoutMs: 500 },
+      presidio: { enabled: false, timeoutMs: 500 },
       llamaPromptGuard: { timeoutMs: 500, scoreThreshold: 0.8 },
       costCircuitBreaker: {
         hourlyThresholdCents: 5_000,

--- a/museum-backend/tests/unit/chat/c3-llm-cache.test.ts
+++ b/museum-backend/tests/unit/chat/c3-llm-cache.test.ts
@@ -116,9 +116,10 @@ describe('C3 — LlmCacheServiceImpl key derivation extension (R6-R10)', () => {
     const keyWithImage = String(cache.set.mock.calls[1][0]);
 
     expect(keyTextOnly).not.toBe(keyWithImage);
-    // Both keys share the prefix shape `llm:v1:{contextClass}:{museumId|none}:{userId|anon}:`
-    expect(keyTextOnly).toMatch(/^llm:v1:generic:none:anon:[0-9a-f]{32}$/);
-    expect(keyWithImage).toMatch(/^llm:v1:generic:none:anon:[0-9a-f]{32}$/);
+    // Both keys share the prefix shape `llm:v2:{contextClass}:{museumId|none}:{userId|anon}:`
+    // (F1 2026-05-19 — KEY_VERSION bumped v1→v2 to isolate voiceMode + audioDescriptionMode entries)
+    expect(keyTextOnly).toMatch(/^llm:v2:generic:none:anon:[0-9a-f]{32}$/);
+    expect(keyWithImage).toMatch(/^llm:v2:generic:none:anon:[0-9a-f]{32}$/);
   });
 
   it('R7 — two requests with the SAME imageContentHash and otherwise identical fields produce the SAME key', async () => {
@@ -418,7 +419,7 @@ describe('C3 — bypass preservation when no visual signature (R12)', () => {
     expect(result.hit).toBe(false);
     // The derived key MUST embed the imageContentHash (different from a no-image key).
     const key = String(cache.get.mock.calls[0][0]);
-    expect(key).toMatch(/^llm:v1:generic:none:anon:[0-9a-f]{32}$/);
+    expect(key).toMatch(/^llm:v2:generic:none:anon:[0-9a-f]{32}$/);
   });
 
   it('R8 — non-regression on existing fail-open contract (cache.get throws → hit=false, contextClass propagated)', async () => {

--- a/museum-backend/tests/unit/chat/chat-cache-key.test.ts
+++ b/museum-backend/tests/unit/chat/chat-cache-key.test.ts
@@ -12,40 +12,76 @@ describe('chat-cache-key — R1 hybrid scoping', () => {
   // Global namespace (cross-user safe)
   // -------------------------------------------------------------------------
   describe('global namespace (generic queries)', () => {
-    it('two users in same museum asking the same generic question share the SAME global key', () => {
-      const a = buildCacheKey(makeCacheKeyInput({ userId: 1 }));
-      const b = buildCacheKey(makeCacheKeyInput({ userId: 2 }));
+    // F2 doctrine amendment (2026-05-19): generic queries route to global key
+    // ONLY when no userId/anonId is passed. Passing an explicit identity now
+    // forces the user/anon-scoped namespace (see isGenericQuery JSDoc).
+    it('two anonymous generic queries in same museum share the SAME global key', () => {
+      const a = buildCacheKey(makeCacheKeyInput({ userId: undefined, anonId: undefined }));
+      const b = buildCacheKey(makeCacheKeyInput({ userId: undefined, anonId: undefined }));
       expect(a).toBe(b);
       expect(a).toMatch(/^chat:llm:global:/);
     });
 
-    it('same user, identical generic query → identical global key', () => {
+    it('passing userId on a generic query routes to user-scoped (F2 amendment)', () => {
+      const a = buildCacheKey(makeCacheKeyInput({ userId: 1 }));
+      const b = buildCacheKey(makeCacheKeyInput({ userId: 2 }));
+      expect(a).not.toBe(b);
+      expect(a).toMatch(/^chat:llm:user:1:/);
+      expect(b).toMatch(/^chat:llm:user:2:/);
+    });
+
+    it('same user, identical generic query → identical user-scoped key', () => {
       const a = buildCacheKey(makeCacheKeyInput({ userId: 42 }));
       const b = buildCacheKey(makeCacheKeyInput({ userId: 42 }));
       expect(a).toBe(b);
+      expect(a).toMatch(/^chat:llm:user:42:/);
     });
 
     it('different museums produce different global keys', () => {
-      const a = buildCacheKey(makeCacheKeyInput({ museumId: 'louvre' }));
-      const b = buildCacheKey(makeCacheKeyInput({ museumId: 'orsay' }));
+      const a = buildCacheKey(
+        makeCacheKeyInput({ museumId: 'louvre', userId: undefined, anonId: undefined }),
+      );
+      const b = buildCacheKey(
+        makeCacheKeyInput({ museumId: 'orsay', userId: undefined, anonId: undefined }),
+      );
       expect(a).not.toBe(b);
     });
 
     it('locale change → different global key', () => {
-      const fr = buildCacheKey(makeCacheKeyInput({ locale: 'fr' }));
-      const en = buildCacheKey(makeCacheKeyInput({ locale: 'en' }));
+      const fr = buildCacheKey(
+        makeCacheKeyInput({ locale: 'fr', userId: undefined, anonId: undefined }),
+      );
+      const en = buildCacheKey(
+        makeCacheKeyInput({ locale: 'en', userId: undefined, anonId: undefined }),
+      );
       expect(fr).not.toBe(en);
     });
 
     it('guideLevel change → different global key', () => {
-      const beginner = buildCacheKey(makeCacheKeyInput({ guideLevel: 'beginner' }));
-      const expert = buildCacheKey(makeCacheKeyInput({ guideLevel: 'expert' }));
+      const beginner = buildCacheKey(
+        makeCacheKeyInput({ guideLevel: 'beginner', userId: undefined, anonId: undefined }),
+      );
+      const expert = buildCacheKey(
+        makeCacheKeyInput({ guideLevel: 'expert', userId: undefined, anonId: undefined }),
+      );
       expect(beginner).not.toBe(expert);
     });
 
     it('audioDescriptionMode change → different global key', () => {
-      const off = buildCacheKey(makeCacheKeyInput({ audioDescriptionMode: false }));
-      const on = buildCacheKey(makeCacheKeyInput({ audioDescriptionMode: true }));
+      const off = buildCacheKey(
+        makeCacheKeyInput({
+          audioDescriptionMode: false,
+          userId: undefined,
+          anonId: undefined,
+        }),
+      );
+      const on = buildCacheKey(
+        makeCacheKeyInput({
+          audioDescriptionMode: true,
+          userId: undefined,
+          anonId: undefined,
+        }),
+      );
       expect(off).not.toBe(on);
     });
   });

--- a/museum-backend/tests/unit/chat/chat-media.service.test.ts
+++ b/museum-backend/tests/unit/chat/chat-media.service.test.ts
@@ -38,7 +38,7 @@ const makeRepo = (messageRow: ChatMessageWithSessionOwnership | null = makeMessa
 const makeTts = (): jest.Mocked<TextToSpeechService> => ({
   synthesize: jest.fn().mockResolvedValue({
     audio: Buffer.from('fake-audio'),
-    contentType: 'audio/mpeg',
+    contentType: 'audio/ogg',
   }),
 });
 
@@ -150,7 +150,7 @@ describe('ChatMediaService', () => {
       const result = await svc.synthesizeSpeech(MESSAGE_ID, 42);
 
       expect(result).not.toBeNull();
-      expect(result!.contentType).toBe('audio/mpeg');
+      expect(result!.contentType).toBe('audio/ogg');
       expect(tts.synthesize).toHaveBeenCalledWith({
         text: 'Hello world',
         voice: 'alloy',
@@ -176,15 +176,36 @@ describe('ChatMediaService', () => {
       const cache = makeCache();
       cache.get.mockResolvedValue({
         audio: Buffer.from('cached-audio').toString('base64'),
-        contentType: 'audio/mpeg',
+        contentType: 'audio/ogg',
       });
       const svc = new ChatMediaService({ repository: repo, tts, cache });
 
       const result = await svc.synthesizeSpeech(MESSAGE_ID, 42);
 
       expect(result).not.toBeNull();
-      expect(result!.contentType).toBe('audio/mpeg');
+      expect(result!.contentType).toBe('audio/ogg');
       expect(tts.synthesize).not.toHaveBeenCalled();
+    });
+
+    // C9.12c (2026-05-17) — cache key MUST include voice id, otherwise switching
+    // user.ttsVoice serves stale audio from a previous voice. The cache key
+    // shape is `tts:v2:<messageId>:<voiceId>` — voice change → cache miss.
+    it('cache key is voice-aware (different voice → cache miss)', async () => {
+      const row = makeMessageRow({ role: 'assistant', text: 'Hello' });
+      const repo = makeRepo(row);
+      const tts = makeTts();
+      const cache = makeCache();
+      cache.get.mockResolvedValue(null);
+      const svc = new ChatMediaService({ repository: repo, tts, cache });
+
+      await svc.synthesizeSpeech(MESSAGE_ID, 42);
+
+      expect(cache.get).toHaveBeenCalledWith(`tts:v2:${MESSAGE_ID}:alloy`);
+      expect(cache.set).toHaveBeenCalledWith(
+        `tts:v2:${MESSAGE_ID}:alloy`,
+        expect.objectContaining({ contentType: 'audio/ogg' }),
+        expect.any(Number),
+      );
     });
 
     it('returns null when assistant message has no text', async () => {

--- a/museum-backend/tests/unit/chat/chat-media.service.test.ts
+++ b/museum-backend/tests/unit/chat/chat-media.service.test.ts
@@ -1,4 +1,6 @@
 import { ChatMediaService } from '@modules/chat/useCase/audio/chat-media.service';
+import { buildCacheKey } from '@modules/chat/useCase/message/chat-cache-key.util';
+import { logger } from '@shared/logger/logger';
 import type { ChatMessageWithSessionOwnership } from '@modules/chat/domain/session/chat.repository.interface';
 import type { ChatMessage } from '@modules/chat/domain/message/chatMessage.entity';
 import type { ChatSession } from '@modules/chat/domain/session/chatSession.entity';
@@ -6,6 +8,12 @@ import type { TextToSpeechService } from '@modules/chat/domain/ports/tts.port';
 import { makeSession, makeMessage, makeSessionUser } from '../../helpers/chat/message.fixtures';
 import { makeChatRepo } from '../../helpers/chat/repo.fixtures';
 import { makeCache } from '../../helpers/chat/cache.fixtures';
+
+jest.mock('@shared/logger/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const loggerWarn = logger.warn as unknown as jest.Mock;
 
 // ── Factories ──────────────────────────────────────────────────────────
 
@@ -324,6 +332,158 @@ describe('ChatMediaService', () => {
         statusCode: 400,
         message: 'Invalid message id format',
       });
+    });
+  });
+
+  // ── F2 feedback-invalidation cartesian ─────────────────────────────────
+  //
+  // Spec F2.1/F2.2/F2.3 (2026-05-19 run, design.md D2). Today's
+  // `chat-media.service.ts:178` hardcodes `audioDescriptionMode:false` AND
+  // omits `voiceMode` entirely — so negative feedback only invalidates the
+  // single `false × undefined` shape and leaves stale entries for the 3 other
+  // cartesian shapes (audioDescriptionMode × voiceMode ∈ {false,true}²)
+  // plus the cross-namespace dual (global + user-scoped).
+  //
+  // These tests pin the corrected contract: 4 shapes × 2 namespaces = 8 del
+  // calls when an owner is present, 4 when anon. Partial failures (one bad
+  // `del`) must NOT skip the other keys (fail-open, per-key try/catch).
+  describe('F2 feedback-invalidation cartesian', () => {
+    const USER_MSG_ID = 'c2c2c2c2-d3d3-4e4e-9f5f-a6a6a6a6a6a6';
+    const ASSISTANT_MSG_ID = MESSAGE_ID;
+    const MUSEUM_ID = 42;
+    const OWNER_ID = 7;
+    const USER_TEXT = 'What is impressionism?';
+
+    /**
+     * Builds the 4 cartesian shape keys for a given namespace (global or user).
+     * @param opts
+     * @param opts.ownerId
+     */
+    const expectedShapeKeys = (opts: { ownerId?: number }): string[] => {
+      const baseInput = {
+        text: USER_TEXT,
+        museumId: String(MUSEUM_ID),
+        locale: 'fr',
+        guideLevel: 'beginner',
+        hasHistory: false,
+        hasAttachment: false,
+        hasGeo: false,
+      };
+      const keys: string[] = [];
+      for (const audioDescriptionMode of [false, true]) {
+        for (const voiceMode of [false, true]) {
+          keys.push(
+            buildCacheKey({
+              ...baseInput,
+              audioDescriptionMode,
+              voiceMode,
+              ...(opts.ownerId !== undefined ? { userId: opts.ownerId } : {}),
+            }),
+          );
+        }
+      }
+      return keys;
+    };
+
+    const setupNegativeFeedbackScenario = (opts: { withOwner: boolean }) => {
+      const session = makeSession({
+        id: SESSION_ID,
+        museumId: MUSEUM_ID,
+        locale: 'fr',
+        user: opts.withOwner ? makeSessionUser(OWNER_ID) : undefined,
+      });
+
+      const userMsg = makeMessage({
+        id: USER_MSG_ID,
+        role: 'user',
+        text: USER_TEXT,
+        session,
+      });
+      const assistantMsg = makeMessage({
+        id: ASSISTANT_MSG_ID,
+        role: 'assistant',
+        text: 'Impressionism is...',
+        session,
+      });
+
+      const row: ChatMessageWithSessionOwnership = { message: assistantMsg, session };
+
+      const repo = makeChatRepo({
+        getMessageById: jest.fn().mockResolvedValue(row),
+        getMessageFeedback: jest.fn().mockResolvedValue(null),
+        upsertMessageFeedback: jest.fn().mockResolvedValue(undefined),
+        listSessionHistory: jest.fn().mockResolvedValue([userMsg, assistantMsg]),
+      });
+      const cache = makeCache();
+      const callerId = opts.withOwner ? OWNER_ID : undefined;
+      const svc = new ChatMediaService({ repository: repo, cache });
+      return { svc, repo, cache, callerId };
+    };
+
+    beforeEach(() => {
+      loggerWarn.mockClear();
+    });
+
+    // F2.2 — authenticated owner: full 4-shape × 2-namespace cartesian (8 keys).
+    it('deletes 8 distinct cartesian keys when session has an owner', async () => {
+      const { svc, cache, callerId } = setupNegativeFeedbackScenario({ withOwner: true });
+
+      await svc.setMessageFeedback(ASSISTANT_MSG_ID, callerId!, 'negative');
+
+      const calledWith = cache.del.mock.calls.map((args) => args[0]);
+      // 8 calls total — 4 shapes × (global + user) namespaces.
+      expect(cache.del).toHaveBeenCalledTimes(8);
+      // All keys distinct (no duplicates).
+      expect(new Set(calledWith).size).toBe(8);
+
+      const expected = [
+        ...expectedShapeKeys({}), // global (no userId)
+        ...expectedShapeKeys({ ownerId: OWNER_ID }), // user-scoped
+      ];
+      expect(new Set(calledWith)).toEqual(new Set(expected));
+    });
+
+    // F2.2 — anonymous session: global namespace only, 4 keys.
+    it('deletes only 4 global keys when session.user is undefined (anon)', async () => {
+      // Anon session: setMessageFeedback enforces ensureSessionOwnership which
+      // requires session.user.id when currentUserId is provided. Use
+      // currentUserId=undefined to traverse the anon path while still
+      // exercising invalidateCacheForFeedback. Repo-level guards skipped here
+      // — this test pins the cache invalidation contract, not auth.
+      const { svc, cache } = setupNegativeFeedbackScenario({ withOwner: false });
+
+      // Anon caller (no currentUserId) — ensureSessionOwnership allows when
+      // both session.user.id and currentUserId are undefined.
+      await svc.setMessageFeedback(ASSISTANT_MSG_ID, undefined as unknown as number, 'negative');
+
+      const calledWith = cache.del.mock.calls.map((args) => args[0]);
+      expect(cache.del).toHaveBeenCalledTimes(4);
+      expect(new Set(calledWith).size).toBe(4);
+      expect(new Set(calledWith)).toEqual(new Set(expectedShapeKeys({})));
+    });
+
+    // F2.3 — partial failure resilience: 1st del rejects, others still attempted.
+    it('continues invalidating remaining keys when first cache.del rejects', async () => {
+      const { svc, cache, callerId } = setupNegativeFeedbackScenario({ withOwner: true });
+      cache.del.mockRejectedValueOnce(new Error('redis down'));
+
+      // Should NOT throw — fail-open contract.
+      await expect(
+        svc.setMessageFeedback(ASSISTANT_MSG_ID, callerId!, 'negative'),
+      ).resolves.toEqual({ messageId: ASSISTANT_MSG_ID, status: 'created' });
+
+      // All 8 del calls still attempted despite the first one rejecting.
+      expect(cache.del).toHaveBeenCalledTimes(8);
+
+      // logger.warn emitted at least once with the redis-down error.
+      expect(loggerWarn).toHaveBeenCalled();
+      const warnCalls = loggerWarn.mock.calls;
+      const sawRedisDown = warnCalls.some((call) => {
+        const payload = call[1] as Record<string, unknown> | undefined;
+        const errStr = payload?.error;
+        return typeof errStr === 'string' && errStr.includes('redis down');
+      });
+      expect(sawRedisDown).toBe(true);
     });
   });
 });

--- a/museum-backend/tests/unit/chat/chat-message-service.test.ts
+++ b/museum-backend/tests/unit/chat/chat-message-service.test.ts
@@ -13,6 +13,7 @@ import type {
 } from '@modules/chat/domain/ports/chat-orchestrator.port';
 import type { ImageStorage } from '@modules/chat/domain/ports/image-storage.port';
 import type { CacheService } from '@shared/cache/cache.port';
+import type { LlmCacheKeyInput, LlmCacheService } from '@modules/chat/useCase/llm/llm-cache.types';
 import { makeSession, makeMessage, makeSessionUser } from '../../helpers/chat/message.fixtures';
 import { makeChatRepo } from '../../helpers/chat/repo.fixtures';
 import { makeCache } from '../../helpers/chat/cache.fixtures';
@@ -1140,6 +1141,46 @@ describe('ChatMessageService', () => {
           text: 'Contact test@example.com about art',
         }),
       );
+    });
+  });
+
+  // ── F1 (W2 follow-up) — buildLlmCacheInput propagates voiceMode ────────
+  //
+  // Spec F1.3 — `buildLlmCacheInput(prep, sanitizedText, input)` MUST forward
+  // `input.context.voiceMode` + `input.context.audioDescriptionMode` into the
+  // returned `LlmCacheKeyInput`. Today the helper drops them on the floor, so
+  // (voice, no-voice) cohorts share the same cache key and cross-serve.
+  //
+  // The helper is private — we test it indirectly via the injected `llmCache`
+  // mock: `tryLlmCacheStore` calls `llmCache.store(cacheInput, ...)` after a
+  // miss, and we assert on the captured `cacheInput`.
+  describe('F1 — LLM cache input propagates voiceMode (C9.10)', () => {
+    const makeLlmCacheMock = (): jest.Mocked<LlmCacheService> => ({
+      classify: jest.fn().mockReturnValue('generic'),
+      lookup: jest.fn().mockResolvedValue({ hit: false, value: null, contextClass: 'generic' }),
+      store: jest.fn().mockResolvedValue(undefined),
+      invalidateMuseum: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('E — buildLlmCacheInput threads input.context.voiceMode=true into LlmCacheKeyInput', async () => {
+      const llmCache = makeLlmCacheMock();
+      const { service } = buildService({ llmCache });
+
+      await service.postMessage(
+        SESSION_ID,
+        {
+          text: 'Tell me about this painting',
+          context: { voiceMode: true },
+        },
+        'req-1',
+        USER_ID,
+      );
+
+      expect(llmCache.store).toHaveBeenCalledTimes(1);
+      const cacheInput = llmCache.store.mock.calls[0][0] as LlmCacheKeyInput & {
+        voiceMode?: boolean;
+      };
+      expect(cacheInput.voiceMode).toBe(true);
     });
   });
 });

--- a/museum-backend/tests/unit/chat/llm-cache.service.test.ts
+++ b/museum-backend/tests/unit/chat/llm-cache.service.test.ts
@@ -169,4 +169,65 @@ describe('LlmCacheServiceImpl', () => {
       loggerSpy.mockRestore();
     });
   });
+
+  // ── F1 (W2 follow-up) — voiceMode + audioDescriptionMode discrimination ──
+  //
+  // Spec F1.1/F1.2/F1.3 — LLM response cache key MUST discriminate on
+  // `voiceMode` and `audioDescriptionMode` (C9.10 — voice produces ~60-80w
+  // prose, no-voice produces ~250-400w with markdown; audio-description
+  // produces an alt-text-style answer). Today both fields are absent from
+  // `LlmCacheKeyInput` → keys collide → wrong-shape responses get cross-served
+  // across (voice, no-voice) / (audio-desc, no-audio-desc) cohorts. T1-GREEN
+  // adds the fields + bumps KEY_VERSION v1→v2 so legacy entries don't bleed.
+  describe('F1 — voiceMode / audioDescriptionMode key discrimination (KEY_VERSION v2)', () => {
+    it('A — two inputs differing only in voiceMode produce different keys', async () => {
+      const cache = buildMockCache();
+      const service = new LlmCacheServiceImpl(cache);
+
+      await service.store(baseInput, { text: 'long-prose' });
+      await service.store({ ...baseInput, voiceMode: true }, { text: 'short-voice' });
+
+      const keyNoVoice = String(cache.set.mock.calls[0][0]);
+      const keyVoice = String(cache.set.mock.calls[1][0]);
+      expect(keyNoVoice).not.toBe(keyVoice);
+    });
+
+    it('B — two inputs differing only in audioDescriptionMode produce different keys', async () => {
+      const cache = buildMockCache();
+      const service = new LlmCacheServiceImpl(cache);
+
+      await service.store({ ...baseInput, audioDescriptionMode: false }, { text: 'normal' });
+      await service.store({ ...baseInput, audioDescriptionMode: true }, { text: 'alt-text' });
+
+      const keyNormal = String(cache.set.mock.calls[0][0]);
+      const keyAltText = String(cache.set.mock.calls[1][0]);
+      expect(keyNormal).not.toBe(keyAltText);
+    });
+
+    it('C — golden-hash for canonical input without voiceMode/audioDescriptionMode', async () => {
+      // Both fields absent → canonical hash MUST be byte-identical to today's
+      // shape (mirror imageContentHash R8/AC6 contract). Only the KEY_VERSION
+      // prefix flips from v1 → v2. Pinned key updated as part of T1-GREEN
+      // (architect note: this golden survives unchanged on the hex side; only
+      // the `:v1:` → `:v2:` segment shifts).
+      const cache = buildMockCache();
+      const service = new LlmCacheServiceImpl(cache);
+
+      await service.store(baseInput, { text: 'x' });
+
+      const key = String(cache.set.mock.calls[0][0]);
+      expect(key).toBe('llm:v2:generic:none:anon:6c3364ef2dd9937a4a72638ab32b67b8');
+    });
+
+    it('D — buildKey output contains the `:v2:` version segment', async () => {
+      const cache = buildMockCache();
+      const service = new LlmCacheServiceImpl(cache);
+
+      await service.store(baseInput, { text: 'x' });
+
+      const key = String(cache.set.mock.calls[0][0]);
+      expect(key).toContain(':v2:');
+      expect(key).not.toContain(':v1:');
+    });
+  });
 });

--- a/museum-backend/tests/unit/chat/llm-sections.test.ts
+++ b/museum-backend/tests/unit/chat/llm-sections.test.ts
@@ -288,4 +288,49 @@ describe('createSummaryFallback — edge cases', () => {
     });
     expect(fallback).not.toContain('You are currently near');
   });
+
+  // C9.10 (2026-05-17) — voiceMode prompt branch.
+  describe('voiceMode (C9.10)', () => {
+    it('includes [VOICE_MODE] instruction and 80-word cap when voiceMode=true', () => {
+      const plan = createLlmSectionPlan({
+        locale: 'en-US',
+        museumMode: false,
+        guideLevel: 'beginner',
+        timeoutSummaryMs: 10000,
+        voiceMode: true,
+      });
+
+      expect(plan[0].prompt).toContain('[VOICE_MODE]');
+      expect(plan[0].prompt).toContain('under 80 words');
+      expect(plan[0].prompt).toContain('no markdown');
+    });
+
+    it('omits [VOICE_MODE] when voiceMode is false/undefined and applies default word limit', () => {
+      const plan = createLlmSectionPlan({
+        locale: 'en-US',
+        museumMode: false,
+        guideLevel: 'beginner',
+        timeoutSummaryMs: 10000,
+      });
+
+      expect(plan[0].prompt).not.toContain('[VOICE_MODE]');
+      // Default non-museum + non-audio mode = 250 word cap.
+      expect(plan[0].prompt).toContain('under 250 words');
+    });
+
+    it('voiceMode overrides audioDescriptionMode word limit (80w wins)', () => {
+      const plan = createLlmSectionPlan({
+        locale: 'en-US',
+        museumMode: true,
+        guideLevel: 'beginner',
+        timeoutSummaryMs: 10000,
+        audioDescriptionMode: true,
+        voiceMode: true,
+      });
+
+      // audioDescriptionMode in museumMode would otherwise be 300w, but voiceMode caps at 80w.
+      expect(plan[0].prompt).toContain('under 80 words');
+      expect(plan[0].prompt).not.toContain('under 300 words');
+    });
+  });
 });

--- a/museum-backend/tests/unit/chat/stt-prompt-bias.test.ts
+++ b/museum-backend/tests/unit/chat/stt-prompt-bias.test.ts
@@ -1,0 +1,98 @@
+import {
+  buildSttPromptBias,
+  buildSttPromptBiasFromVisitContext,
+} from '@modules/chat/useCase/audio/stt-prompt-bias';
+
+describe('buildSttPromptBias (W7.4)', () => {
+  it('returns undefined when nothing to bias', () => {
+    expect(buildSttPromptBias({})).toBeUndefined();
+    expect(buildSttPromptBias({ artworks: [] })).toBeUndefined();
+  });
+
+  it('joins museum name + artist + title with ". " separator', () => {
+    const prompt = buildSttPromptBias({
+      museumName: 'Musée du Louvre',
+      artworks: [
+        { title: 'La Joconde', artist: 'Léonard de Vinci' },
+        { title: 'La Liberté guidant le peuple', artist: 'Eugène Delacroix' },
+      ],
+    });
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('Musée du Louvre');
+    expect(prompt).toContain('Léonard de Vinci');
+    expect(prompt).toContain('La Joconde');
+    expect(prompt).toContain('. ');
+  });
+
+  it('caps the prompt at 896 chars', () => {
+    const big = Array.from({ length: 200 }, (_, i) => ({
+      title: `Artwork title number ${String(i)} that is rather long`,
+      artist: `Artist Name ${String(i)}`,
+    }));
+    const prompt = buildSttPromptBias({ museumName: 'Big Museum', artworks: big });
+    expect(prompt).toBeDefined();
+    expect(prompt!.length).toBeLessThanOrEqual(896);
+  });
+
+  it('deduplicates repeated entries', () => {
+    const prompt = buildSttPromptBias({
+      artworks: [
+        { title: 'La Joconde', artist: 'Léonard de Vinci' },
+        { title: 'La Joconde', artist: 'Léonard de Vinci' },
+        { title: 'La Cène', artist: 'Léonard de Vinci' },
+      ],
+    });
+    expect(prompt).toBeDefined();
+    // "Léonard de Vinci" should appear once even though both works share it.
+    const matches = prompt!.match(/Léonard de Vinci/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('strips PII-shaped tokens (defensive — museum data should never contain PII)', () => {
+    const prompt = buildSttPromptBias({
+      museumName: 'visitor@example.com',
+      artworks: [{ title: 'La Joconde', artist: 'Picasso' }],
+    });
+    expect(prompt).toBeDefined();
+    expect(prompt).not.toContain('visitor@example.com');
+    expect(prompt).toContain('Picasso');
+  });
+
+  it('produces undefined when only PII-shaped tokens were available', () => {
+    expect(
+      buildSttPromptBias({
+        museumName: '+33 6 12 34 56 78',
+        artworks: [{ title: 'someone@example.com', artist: 'a@b.co' }],
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('buildSttPromptBiasFromVisitContext (W7.4)', () => {
+  it('returns undefined for null/empty visit context', () => {
+    expect(buildSttPromptBiasFromVisitContext(null)).toBeUndefined();
+    expect(buildSttPromptBiasFromVisitContext(undefined)).toBeUndefined();
+  });
+
+  it('maps VisitContext.artworksDiscussed shape correctly', () => {
+    const prompt = buildSttPromptBiasFromVisitContext({
+      museumName: 'Musée d’Orsay',
+      museumConfidence: 0.9,
+      artworksDiscussed: [
+        {
+          title: 'Bal du moulin de la Galette',
+          artist: 'Pierre-Auguste Renoir',
+          messageId: 'm1',
+          discussedAt: '2026-05-17T10:00:00Z',
+        },
+      ],
+      roomsVisited: [],
+      detectedExpertise: 'beginner',
+      expertiseSignals: 0,
+      lastUpdated: '2026-05-17T10:00:00Z',
+    });
+    expect(prompt).toContain('Musée d’Orsay');
+    expect(prompt).toContain('Pierre-Auguste Renoir');
+    expect(prompt).toContain('Bal du moulin de la Galette');
+  });
+});

--- a/museum-backend/tests/unit/chat/text-to-speech.test.ts
+++ b/museum-backend/tests/unit/chat/text-to-speech.test.ts
@@ -41,7 +41,7 @@ describe('OpenAiTextToSpeechService', () => {
 
     const result = await service.synthesize({ text: 'Hello world' });
 
-    expect(result.contentType).toBe('audio/mpeg');
+    expect(result.contentType).toBe('audio/ogg');
     expect(Buffer.isBuffer(result.audio)).toBe(true);
     expect(result.audio.length).toBe(3);
 
@@ -51,7 +51,7 @@ describe('OpenAiTextToSpeechService', () => {
     expect(body.input).toBe('Hello world');
     expect(body.model).toBe('gpt-4o-mini-tts');
     expect(body.voice).toBe('alloy');
-    expect(body.response_format).toBe('mp3');
+    expect(body.response_format).toBe('opus');
   });
 
   it('uses voice override when provided', async () => {

--- a/museum-frontend/.maestro/shards.json
+++ b/museum-frontend/.maestro/shards.json
@@ -5,7 +5,17 @@
       "flows": [
         "auth-flow.yaml",
         "auth-persistence.yaml",
+        "auth-login-happy.yaml",
+        "auth-login-invalid-credentials.yaml",
+        "auth-submit-invalid-email.yaml",
+        "auth-register-happy.yaml",
+        "auth-register-duplicate-email.yaml",
+        "auth-register-minor-dob.yaml",
+        "auth-register-password-breached.yaml",
+        "auth-account-delete.yaml",
         "onboarding-flow.yaml",
+        "onboarding-full-carousel.yaml",
+        "onboarding-skip-anonymous.yaml",
         "cert-pinning-smoke.yaml"
       ]
     },
@@ -22,7 +32,12 @@
     },
     {
       "name": "museum",
-      "flows": ["museum-search-geo.yaml", "navigation-flow.yaml"]
+      "flows": [
+        "museum-search-geo.yaml",
+        "navigation-flow.yaml",
+        "nav-stack-deep-links.yaml",
+        "nav-tabs-roundtrip.yaml"
+      ]
     },
     {
       "name": "settings",

--- a/museum-frontend/__tests__/app/onboarding.test.tsx
+++ b/museum-frontend/__tests__/app/onboarding.test.tsx
@@ -6,6 +6,8 @@
  * 2. Next advances through all 4 slides
  * 3. Skip on slide 1 → setHasSeenOnboarding(true) + router.replace home
  * 4. Done on slide 4 → setHasSeenOnboarding(true) + router.replace home
+ * 5. Skip when unauthenticated → markOnboardingComplete NOT called (F3.1)
+ * 6. Done when unauthenticated → markOnboardingComplete NOT called (F3.2)
  */
 
 import '../helpers/test-utils';
@@ -20,6 +22,13 @@ jest.mock('@/features/settings/infrastructure/userProfileStore', () => ({
 }));
 
 const mockMarkOnboardingComplete = jest.fn().mockResolvedValue(undefined);
+// Mutable auth state for per-test override (F3 — T3-GREEN).
+// Default `isAuthenticated:true` preserves existing 4 tests' behavior. The 2
+// new tests flip to `false` via the `setMockAuth` global helper exposed below.
+const mockAuthState = { isAuthenticated: true };
+(globalThis as unknown as { setMockAuth: (v: boolean) => void }).setMockAuth = (v: boolean) => {
+  mockAuthState.isAuthenticated = v;
+};
 jest.mock('@/features/auth/application/AuthContext', () => ({
   // `isAuthenticated: true` is required since 6c39e9365 — the onboarding
   // handleComplete now skips the server-side mark when the user is not yet
@@ -28,7 +37,9 @@ jest.mock('@/features/auth/application/AuthContext', () => ({
   // tail, so we always expose `true`.
   useAuth: () => ({
     markOnboardingComplete: mockMarkOnboardingComplete,
-    isAuthenticated: true,
+    get isAuthenticated() {
+      return mockAuthState.isAuthenticated;
+    },
   }),
 }));
 
@@ -105,6 +116,7 @@ import OnboardingScreen from '@/app/(stack)/onboarding';
 describe('OnboardingScreen v2', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAuthState.isAuthenticated = true;
     mockMarkOnboardingComplete.mockResolvedValue(undefined);
     mockUseOnboarding.mockReturnValue({
       currentStep: 0,
@@ -166,5 +178,41 @@ describe('OnboardingScreen v2', () => {
       expect(mockSetHasSeenOnboarding).toHaveBeenCalledWith(true);
       expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)/home');
     });
+  });
+
+  // ── F3 — isAuthenticated:false branch coverage (T3-RED) ────────────────────
+  // Spec F3.1, F3.2. Production guard in app/(stack)/onboarding.tsx:61-67
+  // (commit 6c39e936) skips markOnboardingComplete() when isAuthenticated is
+  // false. These tests assert that skip path. They require per-test override
+  // of the useAuth mock — wired by T3-GREEN. On red HEAD the module-level
+  // mock hardcodes isAuthenticated:true, so the new tests fail at the
+  // setMockAuth() call (ReferenceError) — that IS the RED state.
+
+  it('Skip on slide 1 when not authenticated does NOT call markOnboardingComplete', async () => {
+    (globalThis as unknown as { setMockAuth: (v: boolean) => void }).setMockAuth(false);
+    render(<OnboardingScreen />);
+    fireEvent.press(screen.getByLabelText('a11y.onboarding.skip'));
+    await waitFor(() => {
+      expect(mockSetHasSeenOnboarding).toHaveBeenCalledWith(true);
+      expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)/home');
+    });
+    expect(mockMarkOnboardingComplete).not.toHaveBeenCalled();
+  });
+
+  it('Done on last slide when not authenticated does NOT call markOnboardingComplete', async () => {
+    (globalThis as unknown as { setMockAuth: (v: boolean) => void }).setMockAuth(false);
+    mockUseOnboarding.mockReturnValue({
+      currentStep: 3,
+      goToStep: mockGoToStep,
+      next: mockNext,
+      isLast: true,
+    });
+    render(<OnboardingScreen />);
+    fireEvent.press(screen.getByLabelText('a11y.onboarding.get_started'));
+    await waitFor(() => {
+      expect(mockSetHasSeenOnboarding).toHaveBeenCalledWith(true);
+      expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)/home');
+    });
+    expect(mockMarkOnboardingComplete).not.toHaveBeenCalled();
   });
 });

--- a/museum-frontend/__tests__/fixtures/cache-key-vectors.json
+++ b/museum-frontend/__tests__/fixtures/cache-key-vectors.json
@@ -79,7 +79,7 @@
       "hasGeo": false
     },
     "normalizedText": "quelle technique ?",
-    "components": "quelle technique ?|fr|beginner|0|0",
+    "components": "quelle technique ?|fr|beginner|0|0|h:1",
     "expectedKeyPrefix": "chat:llm:user:7:met:"
   },
   {
@@ -96,7 +96,7 @@
       "hasGeo": false
     },
     "normalizedText": "tell me about this painting",
-    "components": "tell me about this painting|en|beginner|0|0",
+    "components": "tell me about this painting|en|beginner|0|0|a:1",
     "expectedKeyPrefix": "chat:llm:anon:device-abc123:british-museum:"
   },
   {

--- a/museum-frontend/__tests__/fixtures/cache-key-vectors.json
+++ b/museum-frontend/__tests__/fixtures/cache-key-vectors.json
@@ -12,7 +12,7 @@
       "hasGeo": false
     },
     "normalizedText": "qui a peint la joconde ?",
-    "components": "qui a peint la joconde ?|fr|beginner|0",
+    "components": "qui a peint la joconde ?|fr|beginner|0|0",
     "expectedKeyPrefix": "chat:llm:global:louvre:"
   },
   {
@@ -28,7 +28,7 @@
       "hasGeo": false
     },
     "normalizedText": "who painted the mona lisa?",
-    "components": "who painted the mona lisa?|en|expert|0",
+    "components": "who painted the mona lisa?|en|expert|0|0",
     "expectedKeyPrefix": "chat:llm:global:louvre:"
   },
   {
@@ -44,7 +44,7 @@
       "hasGeo": false
     },
     "normalizedText": "quand a été créée cette œuvre ?",
-    "components": "quand a été créée cette œuvre ?|fr|intermediate|1",
+    "components": "quand a été créée cette œuvre ?|fr|intermediate|1|0",
     "expectedKeyPrefix": "chat:llm:global:orsay:"
   },
   {
@@ -62,7 +62,7 @@
       "geoBucket": "Paris|FR"
     },
     "normalizedText": "que voir ici ?",
-    "components": "que voir ici ?|fr|beginner|0|geo:Paris|FR",
+    "components": "que voir ici ?|fr|beginner|0|0|geo:Paris|FR",
     "expectedKeyPrefix": "chat:llm:user:42:louvre:"
   },
   {
@@ -79,7 +79,7 @@
       "hasGeo": false
     },
     "normalizedText": "quelle technique ?",
-    "components": "quelle technique ?|fr|beginner|0",
+    "components": "quelle technique ?|fr|beginner|0|0",
     "expectedKeyPrefix": "chat:llm:user:7:met:"
   },
   {
@@ -96,7 +96,24 @@
       "hasGeo": false
     },
     "normalizedText": "tell me about this painting",
-    "components": "tell me about this painting|en|beginner|0",
+    "components": "tell me about this painting|en|beginner|0|0",
     "expectedKeyPrefix": "chat:llm:anon:device-abc123:british-museum:"
+  },
+  {
+    "label": "voice-mode namespace (C9.10 — STT path, isolated from text answers)",
+    "input": {
+      "text": "Qui a peint la Joconde ?",
+      "museumId": "louvre",
+      "locale": "fr",
+      "guideLevel": "beginner",
+      "audioDescriptionMode": false,
+      "voiceMode": true,
+      "hasHistory": false,
+      "hasAttachment": false,
+      "hasGeo": false
+    },
+    "normalizedText": "qui a peint la joconde ?",
+    "components": "qui a peint la joconde ?|fr|beginner|0|1",
+    "expectedKeyPrefix": "chat:llm:global:louvre:"
   }
 ]

--- a/museum-frontend/__tests__/shared/lib/dateOfBirth.test.ts
+++ b/museum-frontend/__tests__/shared/lib/dateOfBirth.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for `parseDateOfBirth()` UX-side parser.
+ *
+ * Covers ISO + DMY (slash / dot / dash) variants, leap-year edge cases,
+ * range validation (year < 1900 || > currentYear, month/day bounds), and
+ * defensive fallbacks (non-string / empty / malformed input).
+ *
+ * Purpose (T4-RED, run 2026-05-19-w2-followup-fixpack): cover lines 59-63
+ * (DMY fallback branch) and lines 66-69 (range/leap branches) of
+ * `shared/lib/dateOfBirth.ts` so the FE CI branch-coverage gate (78%)
+ * is restored. F4 is test-only — production code is already correct.
+ */
+
+import { parseDateOfBirth } from '@/shared/lib/dateOfBirth';
+
+describe('parseDateOfBirth', () => {
+  describe('ISO happy path', () => {
+    it('accepts well-formed ISO date and returns it unchanged', () => {
+      expect(parseDateOfBirth('1990-03-15')).toBe('1990-03-15');
+    });
+
+    it('accepts ISO date at lower-bound year (1900)', () => {
+      expect(parseDateOfBirth('1900-01-01')).toBe('1900-01-01');
+    });
+  });
+
+  describe('DMY fallback — slash separator', () => {
+    it('parses DD/MM/YYYY', () => {
+      expect(parseDateOfBirth('15/03/1990')).toBe('1990-03-15');
+    });
+
+    it('parses single-digit day/month with slash and pads them', () => {
+      expect(parseDateOfBirth('5/3/1990')).toBe('1990-03-05');
+    });
+  });
+
+  describe('DMY fallback — dot separator', () => {
+    it('parses DD.MM.YYYY', () => {
+      expect(parseDateOfBirth('15.03.1990')).toBe('1990-03-15');
+    });
+
+    it('parses leap-year Feb 29 with dot separator', () => {
+      expect(parseDateOfBirth('29.02.2020')).toBe('2020-02-29');
+    });
+  });
+
+  describe('DMY fallback — dash separator', () => {
+    it('parses DD-MM-YYYY (dash not confused with ISO)', () => {
+      expect(parseDateOfBirth('15-03-1990')).toBe('1990-03-15');
+    });
+  });
+
+  describe('Calendar validation — leap year', () => {
+    it('rejects Feb 29 on a non-leap year', () => {
+      expect(parseDateOfBirth('29/02/2021')).toBeNull();
+    });
+
+    it('rejects Apr 31 (month with only 30 days)', () => {
+      expect(parseDateOfBirth('31-04-1990')).toBeNull();
+    });
+
+    it('rejects Feb 30 (impossible)', () => {
+      expect(parseDateOfBirth('30/02/1990')).toBeNull();
+    });
+  });
+
+  describe('Year range validation', () => {
+    it('rejects year < 1900', () => {
+      expect(parseDateOfBirth('31/12/1899')).toBeNull();
+    });
+
+    it('rejects year > currentYear (dynamic)', () => {
+      const futureYear = new Date().getUTCFullYear() + 1;
+      expect(parseDateOfBirth(`01/01/${String(futureYear)}`)).toBeNull();
+    });
+  });
+
+  describe('Month range validation', () => {
+    it('rejects month = 0', () => {
+      expect(parseDateOfBirth('15/00/1990')).toBeNull();
+    });
+
+    it('rejects month = 13', () => {
+      expect(parseDateOfBirth('15/13/1990')).toBeNull();
+    });
+  });
+
+  describe('Day range validation', () => {
+    it('rejects day = 0', () => {
+      expect(parseDateOfBirth('00/03/1990')).toBeNull();
+    });
+
+    it('rejects day = 32', () => {
+      expect(parseDateOfBirth('32/03/1990')).toBeNull();
+    });
+  });
+
+  describe('Empty / whitespace input', () => {
+    it('returns null on empty string', () => {
+      expect(parseDateOfBirth('')).toBeNull();
+    });
+
+    it('returns null on whitespace-only string', () => {
+      expect(parseDateOfBirth('   ')).toBeNull();
+    });
+  });
+
+  describe('Non-string input (defensive)', () => {
+    it('returns null on null', () => {
+      expect(parseDateOfBirth(null)).toBeNull();
+    });
+
+    it('returns null on undefined', () => {
+      expect(parseDateOfBirth(undefined)).toBeNull();
+    });
+
+    it('returns null on a numeric value passed through unsafe cast', () => {
+      // Hostile caller (e.g. untyped JS bridge) — must not crash.
+      expect(parseDateOfBirth(42 as unknown as string)).toBeNull();
+    });
+  });
+
+  describe('Malformed input', () => {
+    it('returns null on a non-date string', () => {
+      expect(parseDateOfBirth('not-a-date')).toBeNull();
+    });
+
+    it('returns null on YYYY/MM/DD (ISO regex requires dashes, not slashes)', () => {
+      // The 1990/03/15 pattern matches NEITHER ISO_REGEX (needs `-`) NOR
+      // DMY_REGEX (year of 4 digits must be the LAST group), so it falls
+      // through to null. Pin that contract.
+      expect(parseDateOfBirth('1990/03/15')).toBeNull();
+    });
+
+    it('returns null on partial date', () => {
+      expect(parseDateOfBirth('1990-03')).toBeNull();
+    });
+  });
+});

--- a/museum-frontend/__tests__/shared/lib/env.test.ts
+++ b/museum-frontend/__tests__/shared/lib/env.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for `readEnvString()` canonical env-reader helper.
+ *
+ * Why these tests exist (T4-RED-EXTRA, run 2026-05-19-w2-followup-fixpack):
+ * close the FE branch-coverage gate (78%). The helper was at 75% branches —
+ * the typeof-guard branch (non-string input) was never exercised. Covers:
+ *   - typeof guard rejecting non-string inputs (undefined / number / null / object)
+ *   - trim branch returning undefined on whitespace-only input
+ *   - happy-path returning the trimmed value
+ *
+ * F4-EXTRA is test-only — production code is already correct.
+ */
+
+import { readEnvString } from '@/shared/lib/env';
+
+describe('readEnvString', () => {
+  describe('typeof guard — non-string inputs return undefined', () => {
+    it('returns undefined for undefined', () => {
+      expect(readEnvString(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for null', () => {
+      expect(readEnvString(null)).toBeUndefined();
+    });
+
+    it('returns undefined for a number', () => {
+      expect(readEnvString(42)).toBeUndefined();
+    });
+
+    it('returns undefined for an object', () => {
+      expect(readEnvString({ value: 'x' })).toBeUndefined();
+    });
+  });
+
+  describe('trim branch — empty / whitespace strings return undefined', () => {
+    it('returns undefined for empty string', () => {
+      expect(readEnvString('')).toBeUndefined();
+    });
+
+    it('returns undefined for whitespace-only string', () => {
+      expect(readEnvString('   ')).toBeUndefined();
+    });
+
+    it('returns undefined for tabs and newlines only', () => {
+      expect(readEnvString('\t\n  \r\n')).toBeUndefined();
+    });
+  });
+
+  describe('happy path — returns trimmed string', () => {
+    it('returns the value as-is when no surrounding whitespace', () => {
+      expect(readEnvString('https://api.musaium.com')).toBe('https://api.musaium.com');
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(readEnvString('  value  ')).toBe('value');
+    });
+  });
+});

--- a/museum-frontend/features/chat/application/chatSessionLogic.pure.ts
+++ b/museum-frontend/features/chat/application/chatSessionLogic.pure.ts
@@ -52,6 +52,12 @@ export interface CitationSource {
 /** Metadata attached to an assistant message, including artwork detection and follow-up suggestions. */
 export interface ChatUiMessageMetadata {
   detectedArtwork?: {
+    /**
+     * C9.18 (2026-05-17) — B2B deep-link target. When present alongside a
+     * known museum id, the FE deep-links the chip tap to
+     * `/museum/[id]/artwork/[artworkId]`.
+     */
+    artworkId?: string;
     title?: string;
     artist?: string;
     museum?: string;

--- a/museum-frontend/features/chat/application/computeLocalCacheKey.ts
+++ b/museum-frontend/features/chat/application/computeLocalCacheKey.ts
@@ -64,8 +64,19 @@ export function normalizeQuestion(text: string): string {
  *
  * Default-safe: any undefined flag is treated as TRUE (i.e. as if context
  * were present), so the function falls through to user/anon scoping.
+ *
+ * F2 doctrine amendment (2026-05-19 run) — mirrors backend
+ * `chat-cache-key.util.ts`: when the caller explicitly passes a truthy
+ * `userId` or `anonId`, treat the request as scoped (NOT generic). This
+ * preserves the feedback-driven invalidation path on the user-scoped
+ * variant of generic questions. Generic global keys are reached by NOT
+ * passing userId/anonId at all.
  */
 export function isGenericQuery(input: LocalCacheKeyInput): boolean {
+  const uid = input.userId;
+  if (uid !== undefined && uid !== null && String(uid).length > 0) return false;
+  const aid = input.anonId;
+  if (aid !== undefined && aid !== null && aid.length > 0) return false;
   const hasHistory = input.hasHistory ?? true;
   const hasAttachment = input.hasAttachment ?? true;
   const hasGeo = input.hasGeo ?? true;
@@ -117,6 +128,13 @@ export function computeLocalCacheKey(input: LocalCacheKeyInput): string {
   } else {
     const { namespace, id } = resolveRequester(input);
     const components = [...baseComponents];
+    // F2 (2026-05-19) — when scoped via explicit userId/anonId, hasHistory and
+    // hasAttachment still influence the LLM response, so factor them into the
+    // hash; previously they only flipped the global-vs-scoped branch (which
+    // pre-amendment also produced different keys via prefix change). MUST stay
+    // byte-identical to backend `chat-cache-key.util.ts`.
+    if (input.hasHistory) components.push('h:1');
+    if (input.hasAttachment) components.push('a:1');
     if (input.hasGeo && input.geoBucket && input.geoBucket.length > 0) {
       components.push(`geo:${input.geoBucket}`);
     }

--- a/museum-frontend/features/chat/application/computeLocalCacheKey.ts
+++ b/museum-frontend/features/chat/application/computeLocalCacheKey.ts
@@ -29,6 +29,11 @@ export interface LocalCacheKeyInput {
   locale: string;
   guideLevel?: string;
   audioDescriptionMode?: boolean;
+  /**
+   * C9.10 (2026-05-17) — voiceMode produces a 60-80w prose answer vs ~250-400w
+   * default. MUST be in the cache key to prevent cross-mode leakage.
+   */
+  voiceMode?: boolean;
   /** Authenticated user id; mutually exclusive with `anonId`. */
   userId?: number | string | null;
   /** Anonymous device id from secure-store; mutually exclusive with `userId`. */
@@ -103,6 +108,7 @@ export function computeLocalCacheKey(input: LocalCacheKeyInput): string {
     input.locale,
     input.guideLevel ?? 'beginner',
     input.audioDescriptionMode ? '1' : '0',
+    input.voiceMode ? '1' : '0',
   ];
 
   let key: string;

--- a/museum-frontend/features/chat/application/sendStrategies/sendMessageAudio.ts
+++ b/museum-frontend/features/chat/application/sendStrategies/sendMessageAudio.ts
@@ -40,6 +40,9 @@ export const sendMessageAudio = async (
       locale: context.locale,
       location: context.locationString,
       audioDescriptionMode: context.audioDescriptionMode ? true : undefined,
+      // C9.10 (2026-05-17) — STT inputs always opt into voice-first prompt
+      // (60-80w prose answer) because the response will be TTS-played back.
+      voiceMode: true,
       contentPreferences:
         context.contentPreferences.length > 0
           ? ([...context.contentPreferences] as ContentPreference[])

--- a/museum-frontend/features/chat/application/useChatSession.ts
+++ b/museum-frontend/features/chat/application/useChatSession.ts
@@ -41,9 +41,7 @@ export const useChatSession = (sessionId: string) => {
   const cachedSession = useChatSessionStore((s) => s.sessions[sessionId]);
   const storeUpdateMessages = useChatSessionStore((s) => s.updateMessages);
 
-  const [messages, setMessages] = useState<ChatUiMessage[]>(
-    () => cachedSession?.messages ?? [],
-  );
+  const [messages, setMessages] = useState<ChatUiMessage[]>(() => cachedSession?.messages ?? []);
   const [isSending, setIsSending] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [dailyLimitReached, setDailyLimitReached] = useState(false);
@@ -96,6 +94,34 @@ export const useChatSession = (sessionId: string) => {
     if (messages.length === 0) return;
     storeUpdateMessages(sessionId, messages);
   }, [messages, sessionId, storeUpdateMessages]);
+
+  // C9.2 (2026-05-17) — Audio-description autoplay.
+  // WCAG 2.1 Level A § 1.1.1 (Non-text content): when audioDescriptionMode is
+  // enabled and the assistant attached an `imageDescription`, immediately read
+  // it aloud via expo-speech (device-native TTS). Bypasses the server TTS path
+  // because the description text lives in metadata, not in the message body.
+  // Once per message: tracked in `autoPlayedImageDescIdsRef` to avoid replay
+  // on re-renders / pagination.
+  const autoPlayedImageDescIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!audioDescriptionMode) return;
+    if (isStreamingRef.current) return;
+    const last = messages[messages.length - 1];
+    if (last?.role !== 'assistant') return;
+    const desc = last.metadata?.imageDescription;
+    if (!desc || autoPlayedImageDescIdsRef.current.has(last.id)) return;
+    autoPlayedImageDescIdsRef.current.add(last.id);
+    try {
+      // Lazy-require — mirrors the existing pattern in
+      // `VoiceSessionIntroSheetContent.tsx` so absence of expo-speech in
+      // test/web bundles does not crash the chat screen.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+      const Speech = require('expo-speech') as typeof import('expo-speech');
+      Speech.speak(desc, { language: locale });
+    } catch {
+      // best-effort autoplay; failure must not break the chat UX.
+    }
+  }, [messages, audioDescriptionMode, locale]);
 
   const runWithSending = useCallback(async (fn: () => Promise<boolean>): Promise<boolean> => {
     setIsSending(true);

--- a/museum-frontend/features/chat/infrastructure/chatApi/audio.ts
+++ b/museum-frontend/features/chat/infrastructure/chatApi/audio.ts
@@ -18,6 +18,11 @@ export interface PostAudioMessageParams {
   locale?: string;
   preClassified?: 'art';
   audioDescriptionMode?: boolean;
+  /**
+   * C9.10 (2026-05-17) — auto-set to `true` by the STT path. Constrains the
+   * LLM response to a 60-80w prose-only branch for natural TTS playback.
+   */
+  voiceMode?: boolean;
   contentPreferences?: ContentPreference[];
 }
 
@@ -38,6 +43,7 @@ export const postAudioMessage = async (
     locale,
     preClassified,
     audioDescriptionMode,
+    voiceMode,
     contentPreferences,
   } = params;
 
@@ -56,7 +62,7 @@ export const postAudioMessage = async (
   const extension = fileName.includes('.')
     ? (fileName.split('.').pop()?.toLowerCase() ?? fallbackExt)
     : fallbackExt;
-  const mimeType = audioBlob?.type ?? (audioMimeByExtension[extension] ?? 'audio/mp4');
+  const mimeType = audioBlob?.type ?? audioMimeByExtension[extension] ?? 'audio/mp4';
 
   const formData = new FormData();
   formData.append(
@@ -68,6 +74,7 @@ export const postAudioMessage = async (
       locale,
       preClassified,
       audioDescriptionMode,
+      voiceMode,
       contentPreferences,
     }),
   );

--- a/museum-frontend/features/chat/infrastructure/chatApi/send.ts
+++ b/museum-frontend/features/chat/infrastructure/chatApi/send.ts
@@ -10,10 +10,7 @@ import type {
   CreateSessionResponseDTO,
   PostMessageResponseDTO,
 } from '../../domain/contracts';
-import {
-  isCreateSessionResponseDTO,
-  isPostMessageResponseDTO,
-} from '../../domain/contracts';
+import { isCreateSessionResponseDTO, isPostMessageResponseDTO } from '../../domain/contracts';
 import type { PostMessageStreamParams } from './stream';
 import {
   CHAT_BASE,
@@ -33,6 +30,11 @@ export interface PostMessageParams {
   locale?: string;
   preClassified?: 'art';
   audioDescriptionMode?: boolean;
+  /**
+   * C9.10 (2026-05-17) — set by the STT-message path to opt the response into
+   * a 60-80w prose-only branch suited to TTS playback.
+   */
+  voiceMode?: boolean;
   lowDataMode?: boolean;
   contentPreferences?: ContentPreference[];
 }
@@ -79,9 +81,7 @@ export const createSessionOrThrow = async (
  * Posts a text or image message and returns the assistant response. Builds a
  * multipart form when an image URI is provided; falls back to JSON otherwise.
  */
-export const postMessage = async (
-  params: PostMessageParams,
-): Promise<PostMessageResponseDTO> => {
+export const postMessage = async (params: PostMessageParams): Promise<PostMessageResponseDTO> => {
   const {
     sessionId,
     text,
@@ -92,6 +92,7 @@ export const postMessage = async (
     locale,
     preClassified,
     audioDescriptionMode,
+    voiceMode,
     lowDataMode,
     contentPreferences,
   } = params;
@@ -115,6 +116,7 @@ export const postMessage = async (
         locale,
         preClassified,
         audioDescriptionMode,
+        voiceMode,
         contentPreferences,
       }),
     );
@@ -135,6 +137,7 @@ export const postMessage = async (
         locale,
         preClassified,
         audioDescriptionMode,
+        voiceMode,
         contentPreferences,
       },
     });
@@ -165,7 +168,8 @@ interface SmartSendDeps {
  * Dependencies are injected so the index façade can wire them while keeping
  * each capability module decoupled.
  */
-export const sendMessageSmart = (deps: SmartSendDeps) =>
+export const sendMessageSmart =
+  (deps: SmartSendDeps) =>
   async (params: SendMessageSmartParams): Promise<PostMessageResponseDTO | null> => {
     if (params.imageUri) {
       return deps.postMessage(params);

--- a/museum-frontend/features/chat/infrastructure/chatApi/stream.ts
+++ b/museum-frontend/features/chat/infrastructure/chatApi/stream.ts
@@ -22,6 +22,8 @@ export interface PostMessageStreamParams {
   locale?: string;
   preClassified?: 'art';
   audioDescriptionMode?: boolean;
+  /** C9.10 (2026-05-17) — voice-first STT entry-point flag. */
+  voiceMode?: boolean;
   lowDataMode?: boolean;
   contentPreferences?: ContentPreference[];
   onToken: (text: string) => void;
@@ -99,6 +101,7 @@ export const postMessageStream = async (params: PostMessageStreamParams): Promis
         locale: params.locale,
         preClassified: params.preClassified,
         audioDescriptionMode: params.audioDescriptionMode,
+        voiceMode: params.voiceMode,
         contentPreferences: params.contentPreferences,
       },
     }),

--- a/museum-frontend/features/chat/ui/ArtworkCard.tsx
+++ b/museum-frontend/features/chat/ui/ArtworkCard.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { GlassCard } from '@/shared/ui/GlassCard';
@@ -11,6 +11,12 @@ interface ArtworkCardProps {
   museum?: string;
   room?: string;
   confidence?: number;
+  /**
+   * C9.18 (2026-05-17) — when provided alongside `onPress`, makes the card
+   * tappable for B2B deep-link to the artwork detail screen.
+   */
+  artworkId?: string;
+  onPress?: () => void;
 }
 
 const confidenceKey = (value?: number): 'high' | 'medium' | 'low' | null => {
@@ -22,13 +28,22 @@ const confidenceKey = (value?: number): 'high' | 'medium' | 'low' | null => {
 };
 
 /** Displays a card with detected artwork metadata including title, artist, museum location, and recognition confidence level. */
-export const ArtworkCard = ({ title, artist, museum, room, confidence }: ArtworkCardProps) => {
+export const ArtworkCard = ({
+  title,
+  artist,
+  museum,
+  room,
+  confidence,
+  artworkId,
+  onPress,
+}: ArtworkCardProps) => {
   const { theme } = useTheme();
   const { t } = useTranslation();
   const badgeKey = confidenceKey(confidence);
   const badge = badgeKey ? t(`artworkCard.confidence.${badgeKey}`) : null;
+  const isTappable = Boolean(artworkId && onPress);
 
-  return (
+  const content = (
     <GlassCard style={styles.card} intensity={44}>
       <View style={styles.row}>
         <View style={styles.content}>
@@ -53,6 +68,20 @@ export const ArtworkCard = ({ title, artist, museum, room, confidence }: Artwork
         ) : null}
       </View>
     </GlassCard>
+  );
+
+  if (!isTappable) {
+    return content;
+  }
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={t('artworkCard.openDetail', { defaultValue: 'Open artwork detail' })}
+    >
+      {content}
+    </Pressable>
   );
 };
 

--- a/museum-frontend/features/chat/ui/ChatMessageBubble.tsx
+++ b/museum-frontend/features/chat/ui/ChatMessageBubble.tsx
@@ -46,6 +46,13 @@ interface ChatMessageBubbleProps {
   onRetry?: (message: ChatUiMessage) => void;
   feedbackValue?: 'positive' | 'negative' | null;
   onFeedback?: (messageId: string, value: 'positive' | 'negative') => void;
+  /**
+   * C9.18 (2026-05-17) — B2B deep-link callback fired when the user taps the
+   * detected-artwork chip. Parent owns the actual navigation (it knows the
+   * session museumId). `detectedArtwork` payload (including `artworkId`) is
+   * accessible via `message.metadata`.
+   */
+  onArtworkPress?: (message: ChatUiMessage) => void;
 }
 
 /**
@@ -76,6 +83,7 @@ export const ChatMessageBubble = React.memo(
     onRetry,
     feedbackValue,
     onFeedback,
+    onArtworkPress,
   }: ChatMessageBubbleProps) => {
     const { theme } = useTheme();
     const { t } = useTranslation();
@@ -244,6 +252,14 @@ export const ChatMessageBubble = React.memo(
             museum={message.metadata.detectedArtwork.museum}
             room={message.metadata.detectedArtwork.room}
             confidence={message.metadata.detectedArtwork.confidence}
+            artworkId={message.metadata.detectedArtwork.artworkId}
+            onPress={
+              onArtworkPress
+                ? () => {
+                    onArtworkPress(message);
+                  }
+                : undefined
+            }
           />
         ) : null}
 

--- a/museum-frontend/features/chat/ui/ChatMessageList.tsx
+++ b/museum-frontend/features/chat/ui/ChatMessageList.tsx
@@ -8,6 +8,7 @@ import {
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from 'react-native';
+import { router } from 'expo-router';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
@@ -155,6 +156,25 @@ export const ChatMessageList = ({
     [t],
   );
 
+  // C9.18 (2026-05-17) — B2B deep-link from chat detected-artwork chip.
+  // The full route `/museum/[id]/artwork/[artworkId]` does not exist yet in
+  // V1; we navigate to the existing `museum-detail` screen with `artworkId`
+  // as a passthrough param. The screen will be extended to scroll/highlight
+  // the artwork in a follow-up (TD-NEW). When `museum-detail` cannot resolve
+  // a museum id, the navigation falls back to the museum NAME stored on the
+  // detected artwork — the screen handles that as a best-effort lookup.
+  const handleArtworkPress = useCallback((message: ChatUiMessage) => {
+    const detected = message.metadata?.detectedArtwork;
+    if (!detected?.artworkId) return;
+    router.push({
+      pathname: '/museum-detail',
+      params: {
+        name: detected.museum ?? '',
+        artworkId: detected.artworkId,
+      },
+    });
+  }, []);
+
   const renderItem = useCallback(
     ({ item }: { item: ChatUiMessage }) => {
       const isAssistant = item.role === 'assistant';
@@ -178,6 +198,7 @@ export const ChatMessageList = ({
             onRetry={onRetry}
             feedbackValue={isAssistant ? (feedbackMap[item.id] ?? null) : undefined}
             onFeedback={isAssistant ? handleFeedback : undefined}
+            onArtworkPress={isAssistant ? handleArtworkPress : undefined}
           />
 
           {isAssistant && !isItemStreaming && item.text ? (
@@ -219,6 +240,7 @@ export const ChatMessageList = ({
       feedbackMap,
       handleFeedback,
       handleShare,
+      handleArtworkPress,
       t,
       theme.textTertiary,
       ttsIsPlaying,


### PR DESCRIPTION
## Summary
- **W2 audit-360 scope (10 items)** — voice-aware TTS cache key fixing TD-23, Opus codec output, decoupled S3+DB write (~-150-400ms p50), `voiceMode` prompt branch (80w cap), audio-description autoplay (WCAG 1.1.1), persistent `AiDisclosureFooter` (EU AI Act Art.50, 8 locales), `detectedArtwork` deep-link scaffold, Presidio observeOnly wiring, STT prompt biasing (W7.4), iOS device TTS background config verified.
- **iOS build chain (f9809bd7)** — RN built from source to eliminate `RCTSwiftUI` class duplication; Pods committed (Xcode Cloud, gotcha doctrine).
- **Local dev env** — 3-file `.env` template + `npm run dev:local` orchestrator (Docker + Xcode + Metro), signup form unblocked, onboarding API guarded, pre-push Gate 16 Jest `testTimeout=30s`.

## Test plan
- [x] BE lint + tests: 155/155 (`pnpm lint` + `pnpm test`)
- [x] FE lint + tests: 2834/2836 (2 pre-existing failures unrelated to W2 scope)
- [x] Cache-key parity sentinel BE↔FE: 16/16
- [x] Pre-push 18 gates: passed in 40s
- [ ] Manual TTS smoke: change voice setting → new audio served (no stale cache hit)
- [ ] Manual autoplay smoke: `audioDescriptionAutoplay=true` → narration kicks in on artwork detect
- [ ] iOS local build (Xcode 26 + committed Pods) green on physical device

🤖 Generated with [Claude Code](https://claude.com/claude-code)