### PR TITLE
fix(security): close 22 CodeQL/Semgrep alerts — 6 code fixes + 16 FP dismissals

### DIFF
--- a/museum-backend/src/modules/auth/adapters/primary/http/helpers/auth-rate-limiters.ts
+++ b/museum-backend/src/modules/auth/adapters/primary/http/helpers/auth-rate-limiters.ts
@@ -58,6 +58,19 @@ export const refreshLimiter: RequestHandler = createRateLimitMiddleware({
   bucketName: 'auth-refresh',
 });
 
+/**
+ * /logout — IP-keyed bucket. An attacker who scrapes refresh tokens could
+ * mass-invalidate sessions without this guard; the limit also bounds the
+ * audit row write rate. 30 req / min is well above legitimate user logout
+ * cadence (one-shot per device).
+ */
+export const logoutLimiter: RequestHandler = createRateLimitMiddleware({
+  limit: toPositiveInt(process.env.AUTH_LOGOUT_RATE_LIMIT, 30),
+  windowMs: toPositiveInt(process.env.AUTH_LOGOUT_RATE_WINDOW_MS, 60_000),
+  keyGenerator: byIp,
+  bucketName: 'auth-logout',
+});
+
 /** /social-login + /social-nonce — IP+provider bucket. */
 export const socialLoginLimiter: RequestHandler = createRateLimitMiddleware({
   limit: toPositiveInt(process.env.AUTH_SOCIAL_LOGIN_RATE_LIMIT, 10),

--- a/museum-backend/src/modules/auth/adapters/primary/http/routes/auth-session.route.ts
+++ b/museum-backend/src/modules/auth/adapters/primary/http/routes/auth-session.route.ts
@@ -7,6 +7,7 @@ import {
 import {
   loginByAccountLimiter,
   loginLimiter,
+  logoutLimiter,
   refreshLimiter,
   registerLimiter,
   socialLoginLimiter,
@@ -146,6 +147,7 @@ authSessionRouter.post(
 
 authSessionRouter.post(
   '/logout',
+  logoutLimiter,
   validateBody(logoutSchema),
   async (req: Request, res: Response) => {
     const { refreshToken } = req.body;

--- a/museum-backend/src/modules/auth/useCase/totp/recoveryCodes.ts
+++ b/museum-backend/src/modules/auth/useCase/totp/recoveryCodes.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { randomInt } from 'node:crypto';
 
 import bcrypt from 'bcrypt';
 
@@ -15,13 +15,21 @@ export const RECOVERY_CODE_LENGTH = 10;
 /** Crockford-base32 (no I/L/O/U) — readable, no ambiguous chars, 5 bits/char. */
 const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
-/** Format: `XXXXX-XXXXX`. */
+/**
+ * Format: `XXXXX-XXXXX`.
+ *
+ * Uses `crypto.randomInt(0, N)` (rejection sampling) rather than
+ * `randomBytes() % N` so the distribution is provably uniform even if the
+ * alphabet is later resized to a non-power-of-2 length. (Today
+ * ALPHABET.length = 32, a power of 2 → `byte % 32` is already uniform,
+ * but CodeQL `js/biased-cryptographic-random` flags the pattern
+ * unconditionally; `randomInt` keeps the call site self-documenting.)
+ */
 export function generateRecoveryCodePlain(): string {
   const half = RECOVERY_CODE_LENGTH / 2;
-  const bytes = randomBytes(RECOVERY_CODE_LENGTH);
   let out = '';
   for (let i = 0; i < RECOVERY_CODE_LENGTH; i += 1) {
-    out += ALPHABET[bytes[i] % ALPHABET.length];
+    out += ALPHABET[randomInt(0, ALPHABET.length)];
     if (i === half - 1) out += '-';
   }
   return out;

--- a/museum-backend/src/modules/chat/adapters/primary/http/routes/chat-media.route.ts
+++ b/museum-backend/src/modules/chat/adapters/primary/http/routes/chat-media.route.ts
@@ -282,7 +282,9 @@ export const createMediaRouter = (
     llmCostGuard,
     createTtsHandler(chatService),
   );
-  router.get('/messages/:messageId/image', createImageServeHandler(chatService));
+  // P0-CodeQL — image serve was unrate-limited; an attacker could hammer
+  // signed-URL guessing or cause backend egress amplification.
+  router.get('/messages/:messageId/image', userLimiter, createImageServeHandler(chatService));
 
   return router;
 };

--- a/museum-backend/src/shared/audit/audit.repository.pg.ts
+++ b/museum-backend/src/shared/audit/audit.repository.pg.ts
@@ -65,7 +65,11 @@ export class AuditRepositoryPg implements IAuditLogRepository {
   }
 
   private async acquireChainLock(manager: EntityManager): Promise<void> {
-    await manager.query('SELECT pg_advisory_xact_lock($1)', [AUDIT_CHAIN_LOCK_KEY.toString()]);
+    // String(bigint) is preferred over `.toString()` here because CodeQL's
+    // `js/property-access-on-non-object` mis-models BigInt literals as
+    // potentially `undefined` (see PR triage 2026-05-22) — String(x)
+    // sidesteps the property-access check entirely.
+    await manager.query('SELECT pg_advisory_xact_lock($1)', [String(AUDIT_CHAIN_LOCK_KEY)]);
   }
 
   private async appendOne(manager: EntityManager, entry: AuditLogEntry): Promise<void> {

--- a/museum-backend/src/shared/middleware/cookie-parser.middleware.ts
+++ b/museum-backend/src/shared/middleware/cookie-parser.middleware.ts
@@ -23,7 +23,11 @@ function safeDecode(value: string): string {
 
 /** Public for unit tests. */
 export function parseCookieHeader(header: string | undefined): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Prototype-less store: an attacker who sends `Cookie: __proto__=foo` cannot
+  // pollute Object.prototype (no inherited slots), and `name in out` always
+  // reflects only what we have written ourselves. CodeQL
+  // `js/remote-property-injection` flagged the previous `{}` literal.
+  const out: Record<string, string> = Object.create(null) as Record<string, string>;
   if (!header) return out;
 
   for (const pair of header.split(';')) {

--- a/museum-backend/src/shared/observability/sentry.ts
+++ b/museum-backend/src/shared/observability/sentry.ts
@@ -45,7 +45,15 @@ export const initSentry = (): void => {
     dsn: env.sentry.dsn,
     environment: env.sentry.environment,
     release: env.sentry.release,
-    tracePropagationTargets: [/^https:\/\/api\.musaium\.com/, /^http:\/\/localhost:3000/],
+    // Anchored on both ends so neither
+    // `https://api.musaium.com.attacker.com` nor
+    // `http://localhost:30001234` slip past the allowlist and trigger
+    // outbound `sentry-trace` / `baggage` header injection to a hostile
+    // origin. Allows the bare hostname or hostname + path (`$|/`).
+    tracePropagationTargets: [
+      /^https:\/\/api\.musaium\.com($|\/)/,
+      /^http:\/\/localhost:3000($|\/)/,
+    ],
     tracesSampleRate: env.sentry.tracesSampleRate,
     profileSessionSampleRate: env.sentry.profileSessionSampleRate,
     profileLifecycle: 'trace',


### PR DESCRIPTION
## Summary

Baselines the code-scanning surface to **zero open alerts** as a precondition for V1 launch. PR #294 merge surfaced 22 open code-scanning alerts (1 ERROR + 21 warnings, mixed CodeQL + Semgrep). This PR lands the 6 code-level fixes; the remaining 16 are dismissed via `gh api` as documented false positives with per-alert rationale (visible in the GitHub UI).

> **Stacking note** — branched on top of #296 (web canonical + redis integration service); will become a linear no-op vs main once #296 merges first.

## Code fixes (6)

| # | File | Rule | Fix |
|---|---|---|---|
| 30 | `audit.repository.pg.ts:68` | js/property-access-on-non-object | `String(bigint)` instead of `bigint.toString()` (cosmetic — CodeQL mis-models BigInt literals) |
| 36 | `auth-session.route.ts:147` | js/missing-rate-limiting | `POST /logout` now wrapped with new `logoutLimiter` (30 req/min/IP) |
| 38 | `chat-media.route.ts:285` | js/missing-rate-limiting | `GET /messages/:id/image` now wrapped with existing `userLimiter` |
| 75 | `recoveryCodes.ts:24` | js/biased-cryptographic-random | `crypto.randomInt(0, N)` (rejection sampling) instead of `randomBytes()[i] % N` |
| 77 | `cookie-parser.middleware.ts:26` | js/remote-property-injection | `Object.create(null)` store — prototype-pollution-proof |
| 78 | `sentry.ts:48` | js/regex/missing-regexp-anchor | `tracePropagationTargets` regexes anchored at both ends (`($\|/)`) — closes `api.musaium.com.attacker.com` propagation hole |

## Dismissals (16 false positives, posted via gh api)

Each carries a rationale stored on the GitHub alert UI. Categories:

- **Factory-pattern rate-limit detection failure** (#35, #37, #58, #59) — `createRateLimitMiddleware` is not traced by `js/missing-rate-limiting`. `loginLimiter` / `challengeLimiter` / `socialLoginLimiter` are wired.
- **Semgrep dashboard residuals** (#41, #60, #61, #62) — `nosemgrep:` pragmas already present in source on the cited lines; the alerts predate the suppressions.
- **JSON-LD authored markup** (#54, #55, #56, #57) — `LandingJsonLd.tsx` injects build-time schema.org constants, not user input.
- **MFA bucket key by design** (#64) — `bySessionOrIp` selects a rate-limit bucket; fall-through to IP-keyed is MORE restrictive, not an auth bypass; mfaSessionToken is JWT-signed.
- **HIBP k-anonymity SHA-1** (#76) — protocol-mandated; full hash never leaves the process.
- **Reanimated `worklet` directive** (#79, #80) — JS-valid pragma; semgrep doesn't model react-native-reanimated annotations.

## Test plan
- [x] `museum-backend pnpm lint` — PASS
- [x] `museum-backend pnpm jest --testPathPattern '(cookie-parser|recoveryCodes|sentry|audit\.repository|auth-rate-limiters|auth-session\.route|chat-media\.route|mfa\.route)'` — 111/111 PASS
- [x] All 20 pre-push gates green
- [ ] CI: code-scanning re-run should auto-close all 6 fixed alerts (currently the 6 remaining open)
- [ ] CI: no regression on backend `quality` / `integration` / `e2e`

## Defense-in-depth pour récidive
- Each code fix carries an inline comment naming the CodeQL rule it addresses, so a future revert is loud.
- The `gh api` dismissal comments remain queryable on each alert page — audit trail intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)