### PR TITLE
fix(hooks): re-chaîne husky × git-lfs (anti-clobber UFR-020)

### DIFF
--- a/.github/workflows/sentinel-mirror.yml
+++ b/.github/workflows/sentinel-mirror.yml
@@ -129,6 +129,9 @@ jobs:
       - name: 'Mirror Gate P15 — compose-parity (dev vs prod docker-compose)'
         run: node scripts/sentinels/compose-parity.mjs
 
+      - name: 'Mirror Gate P23 — husky × git-lfs hook integrity (UFR-020)'
+        run: node scripts/sentinels/husky-lfs-integrity.mjs
+
       - name: 'Mirror Gate P20 — roadmap claim resolves (UFR-024)'
         run: node scripts/sentinels/roadmap-claim-resolves.mjs
 

--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs pre-push "$@"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Musaium post-checkout — git-lfs smudge
+# =============================================================================
+# Fires after `git checkout` / `git switch`. Runs `git lfs post-checkout` so
+# LFS-tracked files (see .gitattributes — React.xcframework) are smudged to
+# their real content on the working tree.
+#
+# Chained HERE inside the tracked husky hook (core.hooksPath = .husky) instead
+# of letting `git lfs install` clobber it. The marker line lets the
+# husky-lfs-integrity sentinel tell a real hook apart from a bare git-lfs
+# clobber wrapper. DO NOT remove the marker.
+# husky-lfs-integrity: musaium-gate
+# =============================================================================
+set +e
+
+if command -v git-lfs >/dev/null 2>&1; then
+  git lfs post-checkout "$@"
+fi
+
+exit 0

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Musaium post-commit — git-lfs bookkeeping
+# =============================================================================
+# Fires after a successful `git commit`. Runs `git lfs post-commit` so LFS
+# pointer bookkeeping stays consistent after a commit that touched LFS-tracked
+# files (see .gitattributes).
+#
+# Chained HERE inside the tracked husky hook (core.hooksPath = .husky) instead
+# of letting `git lfs install` clobber it. The marker line lets the
+# husky-lfs-integrity sentinel tell a real hook apart from a bare git-lfs
+# clobber wrapper. DO NOT remove the marker.
+# husky-lfs-integrity: musaium-gate
+# =============================================================================
+set +e
+
+if command -v git-lfs >/dev/null 2>&1; then
+  git lfs post-commit "$@"
+fi
+
+exit 0

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -13,8 +13,20 @@
 # completing cleanly, which is annoying when the user knows they're
 # about to run `pnpm bootstrap` anyway. We surface the issue + the fix
 # command; the hard gate is in pre-commit (Gate 6).
+#
+# Git LFS: this hook ALSO runs `git lfs post-merge` so LFS objects are smudged
+# after a merge. Chained HERE inside the tracked husky hook (not via
+# `git lfs install`, which would clobber it). The marker line lets the
+# husky-lfs-integrity sentinel tell a real hook apart from a bare git-lfs
+# clobber wrapper. DO NOT remove the marker.
+# husky-lfs-integrity: musaium-gate
 # =============================================================================
 set +e
+
+# ─── Git LFS — smudge after merge (non-fatal if git-lfs absent) ────────────
+if command -v git-lfs >/dev/null 2>&1; then
+  git lfs post-merge "$@"
+fi
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
 [ -z "$repo_root" ] && exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -28,8 +28,21 @@
 #  17. Affected tests FE                            — jest --findRelatedTests
 #  18. Affected tests Web                           — vitest run --changed
 #  19. Prometheus metric-naming ratchet (BE)         — node scripts/sentinels/metric-naming.mjs
+#
+# Git LFS: this hook ALSO runs `git lfs pre-push` so LFS objects (see
+# .gitattributes — React.xcframework) upload on push. The LFS step is chained
+# HERE (inside the tracked husky hook) instead of letting `git lfs install`
+# clobber this file — see scripts/install-git-lfs-hooks.mjs + the
+# husky-lfs-integrity sentinel. The marker line below lets that sentinel tell a
+# real gate apart from a bare git-lfs clobber wrapper. DO NOT remove the marker.
+# husky-lfs-integrity: musaium-gate
 # =============================================================================
 set -e
+
+# Buffer the ref list git delivers on stdin BEFORE any gate runs, so we can feed
+# it to `git lfs pre-push` at the end (stdin is single-pass; the gates below do
+# not consume it, but buffering is robust against future gates that might).
+lfs_stdin="$(cat)"
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -315,3 +328,14 @@ echo ""
 echo "[pre-push] ═══════════════════════════════════════════════════"
 echo "[pre-push] ✅ All 21 gates passed in ${total}s — push authorized"
 echo "[pre-push] ═══════════════════════════════════════════════════"
+
+# ─── Git LFS — upload LFS objects for this push ────────────────────────────
+# Runs only AFTER every gate passed (a rejected push must not upload). Feeds the
+# buffered ref list back on stdin. Non-fatal if git-lfs is absent so a
+# contributor without LFS installed is not blocked (committed LFS objects simply
+# won't re-upload — CI mirror still enforces correctness).
+if command -v git-lfs >/dev/null 2>&1; then
+  printf '%s' "$lfs_stdin" | git lfs pre-push "$@"
+else
+  echo "[pre-push] ⚠ git-lfs not on PATH — skipping LFS object upload (install git-lfs: https://git-lfs.com)"
+fi

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "musaium-monorepo",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky && node scripts/install-git-lfs-hooks.mjs",
     "bootstrap": "cd museum-backend && pnpm install --frozen-lockfile && cd ../museum-frontend && npm install && cd ../museum-web && pnpm install --frozen-lockfile",
     "build:tokens": "cd design-system && npm run build",
     "dev:stack": "bash scripts/dev-stack.sh",
@@ -22,7 +22,8 @@
     "sentinel:screen-test-coverage": "node scripts/sentinels/screen-test-coverage.mjs",
     "sentinel:compose-parity": "node scripts/sentinels/compose-parity.mjs",
     "sentinel:dev-container-env-drift": "bash scripts/sentinels/dev-container-env-drift.sh",
-    "sentinel:metric-naming": "node scripts/sentinels/metric-naming.mjs"
+    "sentinel:metric-naming": "node scripts/sentinels/metric-naming.mjs",
+    "sentinel:husky-lfs-integrity": "node scripts/sentinels/husky-lfs-integrity.mjs"
   },
   "devDependencies": {
     "husky": "^9.1.7"

--- a/scripts/install-git-lfs-hooks.mjs
+++ b/scripts/install-git-lfs-hooks.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * install-git-lfs-hooks — make the husky × git-lfs hook chain clobber-proof.
+ *
+ * Run by the root `prepare` script
+ * (`husky && node scripts/install-git-lfs-hooks.mjs`) so EVERY `npm/pnpm
+ * install` re-establishes a layout that survives both `husky` and a future
+ * `git lfs install`, WITHOUT ever calling `git lfs install` ourselves.
+ *
+ * ── Why this is needed (verified against husky@9.1.7 source) ────────────────
+ * `husky` (the `prepare` step) does `git config core.hooksPath .husky/_` and
+ * writes 39-byte delegator wrappers `.husky/_/<hook>` that `. "$(dirname)/h"`
+ * → which runs the real `.husky/<hook>` (our gates). A subsequent
+ * `git lfs install` writes its own 4 hooks into whatever core.hooksPath points
+ * at — so when hooksPath is `.husky/_` it OVERWRITES the husky delegators with
+ * bare `git lfs <hook>` wrappers, severing the chain to `.husky/pre-push` (the
+ * 21-gate). That is exactly the silent UFR-020 regression we are guarding.
+ *
+ * ── What this script does (idempotent, exit 0 always) ───────────────────────
+ *   1. Pin `core.hooksPath = .husky` (overriding husky's `.husky/_`). git then
+ *      runs the tracked `.husky/<hook>` directly — no delegator to clobber, and
+ *      a future `git lfs install` would land on `.husky/<hook>` where the
+ *      husky-lfs-integrity sentinel detects it.
+ *   2. Purge any bare git-lfs wrapper that a prior `git lfs install` left in
+ *      `.husky/_/` (they are inert once hooksPath=.husky, but removing them
+ *      prevents a relapse if hooksPath ever falls back to `.husky/_`).
+ *   3. Self-heal: if a tracked `.husky/<hook>` has the Musaium marker but lost
+ *      its `git lfs <hook>` chain, re-append the non-fatal LFS block.
+ *
+ * Never reconstructs gate logic; never runs `git lfs install`; safe when
+ * git-lfs is not installed (only edits config + shell text).
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const huskyDir = path.join(repoRoot, '.husky');
+const underscoreDir = path.join(huskyDir, '_');
+
+const MARKER = 'husky-lfs-integrity: musaium-gate';
+const HOOKS = ['pre-push', 'post-checkout', 'post-commit', 'post-merge'];
+
+function lfsBlock(hook) {
+  return [
+    '',
+    `# ─── Git LFS (self-healed by scripts/install-git-lfs-hooks.mjs) ───`,
+    `if command -v git-lfs >/dev/null 2>&1; then`,
+    `  git lfs ${hook} "$@"`,
+    `fi`,
+    '',
+  ].join('\n');
+}
+
+function isBareLfsWrapper(txt, hook) {
+  // git-lfs writes a tiny (<400B) wrapper whose only command is `git lfs <hook>`
+  return new RegExp(`git\\s+lfs\\s+${hook}\\b`).test(txt) && !txt.includes(MARKER);
+}
+
+// ── Step 1 — pin core.hooksPath to .husky (override husky's .husky/_) ────────
+try {
+  const cur = execFileSync('git', ['config', 'core.hooksPath'], { cwd: repoRoot, encoding: 'utf8' }).trim();
+  // accept either the relative `.husky` or an absolute path ending in /.husky
+  if (cur !== '.husky' && !/[/\\]\.husky$/.test(cur)) {
+    execFileSync('git', ['config', 'core.hooksPath', '.husky'], { cwd: repoRoot });
+    console.log(`[install-git-lfs-hooks] pinned core.hooksPath = .husky (was "${cur || 'unset'}")`);
+  }
+} catch (e) {
+  console.warn(`[install-git-lfs-hooks] WARN could not read/set core.hooksPath (${e.message}) — continuing.`);
+}
+
+// ── Step 2 — purge bare git-lfs wrappers left under .husky/_/ ─────────────────
+try {
+  if (fs.existsSync(underscoreDir)) {
+    for (const hook of HOOKS) {
+      const p = path.join(underscoreDir, hook);
+      if (!fs.existsSync(p)) continue;
+      const txt = fs.readFileSync(p, 'utf8');
+      if (isBareLfsWrapper(txt, hook)) {
+        fs.rmSync(p, { force: true });
+        console.log(`[install-git-lfs-hooks] purged inert git-lfs wrapper .husky/_/${hook}`);
+      }
+    }
+  }
+} catch (e) {
+  console.warn(`[install-git-lfs-hooks] WARN purge of .husky/_/ failed (${e.message}) — continuing.`);
+}
+
+// ── Step 3 — self-heal the LFS chain inside the tracked .husky/<hook> files ──
+let changed = 0;
+for (const hook of HOOKS) {
+  const p = path.join(huskyDir, hook);
+  if (!fs.existsSync(p)) {
+    console.warn(`[install-git-lfs-hooks] WARN .husky/${hook} missing — not recreated (the sentinel will flag it).`);
+    continue;
+  }
+  const txt = fs.readFileSync(p, 'utf8');
+  if (new RegExp(`git\\s+lfs\\s+${hook}\\b`).test(txt)) continue; // already chained — no-op
+  if (!txt.includes(MARKER)) {
+    console.warn(
+      `[install-git-lfs-hooks] WARN .husky/${hook} lacks the marker AND the LFS chain — leaving untouched (looks clobbered; the sentinel will flag it).`,
+    );
+    continue;
+  }
+  fs.writeFileSync(p, `${txt.replace(/\n*$/, '\n')}${lfsBlock(hook)}`);
+  console.log(`[install-git-lfs-hooks] healed .husky/${hook} — re-appended \`git lfs ${hook}\` chain.`);
+  changed += 1;
+}
+
+if (changed === 0) console.log('[install-git-lfs-hooks] OK — husky × git-lfs chain intact.');
+process.exit(0);

--- a/scripts/sentinels/husky-lfs-integrity.mjs
+++ b/scripts/sentinels/husky-lfs-integrity.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Sentinel: husky-lfs-integrity
+ *
+ * Guards against the `git lfs install` clobber that silently deletes the
+ * Musaium husky gates (UFR-020 NO-BYPASS). Background:
+ *
+ *   `core.hooksPath` is configured to `.husky` (absolute). git therefore runs
+ *   `.husky/<hook>` directly. `git lfs install` writes its 4 hooks
+ *   (pre-push / post-checkout / post-commit / post-merge) into whatever
+ *   `core.hooksPath` points at — so a future `git lfs install` would OVERWRITE
+ *   `.husky/pre-push` (the 21-gate) with a bare 3-line git-lfs wrapper,
+ *   silently disabling every shift-left gate.
+ *
+ *   The fix chains `git lfs <hook>` INSIDE the tracked husky hooks (the layout
+ *   `git lfs install --manual` itself recommends) and tags each real gate with
+ *   a marker comment. This sentinel asserts the chained layout is intact and
+ *   that no hook has been reduced to a bare git-lfs wrapper (the clobber
+ *   signature).
+ *
+ * Checks (all must hold; any failure => exit 1):
+ *   1. `.husky/pre-push` contains the MUSAIUM marker AND chains `git lfs pre-push`.
+ *   2. `.husky/post-checkout` exists, has the marker, chains `git lfs post-checkout`.
+ *   3. `.husky/post-commit` exists, has the marker, chains `git lfs post-commit`.
+ *   4. `.husky/post-merge` has the marker, chains `git lfs post-merge`, AND
+ *      keeps the workspace-links sentinel call.
+ *   5. No `.husky/<hook>` is a bare git-lfs-only wrapper (clobber signature:
+ *      contains `git lfs <hook>` but NOT the Musaium marker).
+ *   6. The inert git-lfs files committed under `.husky/_/` are no longer
+ *      tracked (they are dead — `.husky/_` is not the hooksPath — and were the
+ *      misleading artifact of the original clobber).
+ *   7. Runtime guard (local only, skipped where `.husky/_/` absent — e.g. fresh
+ *      CI checkout before `prepare`): IF `core.hooksPath` resolves to `.husky/_`
+ *      AND a `.husky/_/<hook>` is a bare git-lfs wrapper, the active gate is
+ *      severed right now — FAIL. Run `pnpm prepare` to re-pin hooksPath=.husky
+ *      and purge the wrapper (scripts/install-git-lfs-hooks.mjs).
+ *
+ * Exit 0 = pass / 1 = violation.
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..');
+const huskyDir = path.join(repoRoot, '.husky');
+
+/** The marker comment that tags a real Musaium husky hook (vs a clobber). */
+const MARKER = 'husky-lfs-integrity: musaium-gate';
+
+const violations = [];
+
+function read(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function lfsChain(hook) {
+  // matches `git lfs <hook>` with any surrounding whitespace / quoting of args
+  return new RegExp(`git\\s+lfs\\s+${hook}\\b`);
+}
+
+// ── Check 1 — pre-push: marker + LFS chain ──────────────────────────────────
+{
+  const p = path.join(huskyDir, 'pre-push');
+  const txt = read(p);
+  if (txt === null) {
+    violations.push('.husky/pre-push is missing — the 21-gate is gone');
+  } else {
+    if (!txt.includes(MARKER))
+      violations.push(`.husky/pre-push lacks the "${MARKER}" marker (may have been clobbered by \`git lfs install\`)`);
+    if (!lfsChain('pre-push').test(txt))
+      violations.push('.husky/pre-push does not chain `git lfs pre-push` — LFS objects will not upload on push');
+  }
+}
+
+// ── Checks 2 & 3 — post-checkout / post-commit must exist + chain LFS ────────
+for (const hook of ['post-checkout', 'post-commit']) {
+  const p = path.join(huskyDir, hook);
+  const txt = read(p);
+  if (txt === null) {
+    violations.push(`.husky/${hook} is missing — \`git lfs ${hook}\` is not wired into the active hooksPath`);
+    continue;
+  }
+  if (!txt.includes(MARKER)) violations.push(`.husky/${hook} lacks the "${MARKER}" marker`);
+  if (!lfsChain(hook).test(txt)) violations.push(`.husky/${hook} does not chain \`git lfs ${hook}\``);
+}
+
+// ── Check 4 — post-merge: marker + LFS chain + workspace-links preserved ─────
+{
+  const p = path.join(huskyDir, 'post-merge');
+  const txt = read(p);
+  if (txt === null) {
+    violations.push('.husky/post-merge is missing');
+  } else {
+    if (!txt.includes(MARKER)) violations.push(`.husky/post-merge lacks the "${MARKER}" marker`);
+    if (!lfsChain('post-merge').test(txt))
+      violations.push('.husky/post-merge does not chain `git lfs post-merge`');
+    if (!/workspace-links\.mjs/.test(txt))
+      violations.push('.husky/post-merge lost the workspace-links sentinel call (regression)');
+  }
+}
+
+// ── Check 5 — no hook reduced to a bare git-lfs wrapper (clobber signature) ──
+{
+  let entries = [];
+  try {
+    entries = fs.readdirSync(huskyDir, { withFileTypes: true });
+  } catch {
+    violations.push('.husky/ directory not found');
+  }
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    const name = e.name;
+    // only the 4 hooks git-lfs ever writes can carry the clobber signature
+    if (!['pre-push', 'post-checkout', 'post-commit', 'post-merge'].includes(name)) continue;
+    const txt = read(path.join(huskyDir, name));
+    if (txt === null) continue;
+    const isBareLfs = lfsChain(name).test(txt) && !txt.includes(MARKER);
+    if (isBareLfs)
+      violations.push(
+        `.husky/${name} looks like a bare git-lfs wrapper (chains git-lfs but lacks the Musaium marker) — \`git lfs install\` clobbered the gate`,
+      );
+  }
+}
+
+// ── Check 6 — inert .husky/_/* git-lfs files no longer tracked ───────────────
+{
+  let tracked = '';
+  try {
+    tracked = execSync('git ls-files .husky/_/', { cwd: repoRoot, encoding: 'utf8' });
+  } catch {
+    tracked = '';
+  }
+  const clobberArtifacts = tracked
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => /^\.husky\/_\/(pre-push|post-checkout|post-commit|post-merge)$/.test(l));
+  for (const f of clobberArtifacts)
+    violations.push(`${f} is tracked but inert (it is a committed git-lfs clobber artifact; \`git rm\` it — husky regenerates .husky/_/ locally)`);
+}
+
+// ── Check 7 — runtime guard: hooksPath=.husky/_ with a clobbered delegator ──
+// Local-only. On a fresh CI checkout .husky/_/ does not exist yet (husky runs
+// at install time) — in that case this check is a no-op, the tracked-tree
+// checks 1-6 already prove the layout is correct.
+{
+  let hooksPath = '';
+  try {
+    hooksPath = execSync('git config core.hooksPath', { cwd: repoRoot, encoding: 'utf8' }).trim();
+  } catch {
+    hooksPath = '';
+  }
+  const usesUnderscore = /(^|[/\\])\.husky[/\\]_$/.test(hooksPath) || hooksPath === '.husky/_';
+  const underscoreDir = path.join(huskyDir, '_');
+  if (usesUnderscore && fs.existsSync(underscoreDir)) {
+    for (const hook of ['pre-push', 'post-checkout', 'post-commit', 'post-merge']) {
+      const txt = read(path.join(underscoreDir, hook));
+      if (txt === null) continue;
+      if (lfsChain(hook).test(txt) && !txt.includes(MARKER))
+        violations.push(
+          `core.hooksPath="${hooksPath}" AND .husky/_/${hook} is a bare git-lfs wrapper — the ${hook} gate is severed RIGHT NOW. Run \`pnpm prepare\` to re-pin hooksPath=.husky and purge it.`,
+        );
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('[sentinel:husky-lfs-integrity] FAIL:');
+  for (const v of violations) console.error(`  - ${v}`);
+  console.error('[sentinel:husky-lfs-integrity] Fix: re-chain `git lfs <hook>` inside the tracked .husky/<hook> files');
+  console.error('[sentinel:husky-lfs-integrity] (see scripts/install-git-lfs-hooks.mjs). NEVER run `git lfs install` against core.hooksPath=.husky.');
+  process.exit(1);
+}
+
+console.log('[sentinel:husky-lfs-integrity] PASS — husky gates intact, git-lfs chained, no clobber detected');
+process.exit(0);


### PR DESCRIPTION
## Problème (root cause vérifié)

`git lfs install` écrit ses 4 hooks (`pre-push`/`post-checkout`/`post-commit`/`post-merge`) dans le dossier pointé par `core.hooksPath`. husky@9.1.7 (`prepare: "husky"`) configure `core.hooksPath=.husky/_` et y écrit des délégateurs 39 o qui exécutent les vrais hooks `.husky/<hook>` (le 21-gate NO-BYPASS). Un `git lfs install` antérieur a **écrasé** ces délégateurs par des wrappers `git lfs <hook>` (350–360 o), **sévérant le 21-gate pre-push silencieusement** (viole UFR-020 en local).

Vérifié contre le source husky (`node_modules/husky/index.js:14` fait `git config core.hooksPath .husky/_`). Le repo a actuellement `core.hooksPath=.husky` (mis manuellement après coup) qui contourne le `.husky/_` cassé → les gates tournent aujourd'hui, mais **le prochain `pnpm install` re-pointe hooksPath vers `.husky/_` et ré-expose le clobber**. État « réparé par accident », fragile.

Bonus : les hooks `git lfs pre-push`/`post-*` (upload + smudge des objets LFS — `React.xcframework` dans `.gitattributes`) ne tournaient plus du tout dans le hooksPath actif.

## Fix (défense en profondeur)

1. **Chaînage LFS dans les hooks husky trackés** (le layout que `git lfs install --manual` recommande lui-même) :
   - `.husky/pre-push` : buffer stdin → 21 gates → `git lfs pre-push` (upload seulement si push autorisé). Marqueur `musaium-gate`.
   - `.husky/post-merge` : `git lfs post-merge` + garde workspace-links.
   - `.husky/post-checkout` + `.husky/post-commit` : créés, chaînent git-lfs.
   - `git rm` des 4 wrappers git-lfs inertes committés sous `.husky/_/`.
2. **PRÉVENTION** — `scripts/install-git-lfs-hooks.mjs` au `prepare` : pin `core.hooksPath=.husky` (annule le `.husky/_` de husky), purge les wrappers git-lfs clobbés dans `.husky/_/`, self-heal idempotent du chaînage LFS. Jamais de `git lfs install`. `execFileSync` (pas de shell).
3. **DÉTECTION** — `scripts/sentinels/husky-lfs-integrity.mjs` : 7 checks (marqueur présent, chaîne LFS, post-* présents, pas de bare git-lfs wrapper = signature de clobber, `.husky/_/*` non trackés, garde runtime `hooksPath=.husky/_` + wrapper clobbé). Wiré dans `sentinel-mirror.yml` (Gate P23).

## Preuves (verbatim, exécuté)

- Sentinel **rouge avant** (exit 1, 10 violations) → **vert après** (exit 0).
- Clobber simulé attrapé end-to-end (signature tracked **et** garde runtime `hooksPath=.husky/_`) ; le helper re-pin + purge → re-vert.
- `bash -n` OK sur les 5 hooks ; pre-commit 8/8 ; **les 21 gates pre-push ont réellement tourné et passé (429 s) à ce push** (aucun bypass).

## Notes
- Header prose pre-push « 19 gates / Gate 1/10 » = drift pré-existant, non touché (frozen-test / hors scope).
- Le clobber runtime du repo principal `.husky/_/` est gitignored (`*`) → nettoyé par `install-git-lfs-hooks.mjs` au prochain `prepare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)