### PR TITLE
ci(mobile): Android flow remediation — chat/museum/settings shards

### DIFF
--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -352,10 +352,12 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: museum-frontend/package-lock.json
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5
-        with:
-          version: 10
+      # No `pnpm/action-setup` here: it errored "Multiple versions of pnpm
+      # specified" because its `version: 10` input conflicts with the root
+      # package.json `packageManager: pnpm@11.2.2`. The backend boot script
+      # (maestro-runner-setup.sh) runs `corepack enable`, which resolves pnpm
+      # per-package from each package.json's `packageManager` field
+      # (museum-backend = 10.8.0) — the canonical way the backend is launched.
       - name: Setup Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -293,7 +293,7 @@ jobs:
   # heavy — smoke gives a fast pre-merge guard rail on the critical happy paths
   # while nightly keeps full coverage.
   maestro-matrix:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -319,7 +319,7 @@ jobs:
   # suite into a permanent CI guard rail (UFR-021) and closing the CNIL age-15
   # e2e blocker. iOS Maestro stays nightly — HVF on iOS needs a Mac runner.
   maestro-shard:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: [prebuild, maestro-matrix]
     runs-on: ubuntu-latest
     # 70min cap: a nightly full shard (~45min, 18 flows × ~2.5min) plus a
@@ -412,6 +412,12 @@ jobs:
           PGDATABASE: museum_dev
           REDIS_HOST: localhost
           REDIS_PORT: '6379'
+          # Keep the host backend lightweight so it doesn't contend with the
+          # software-GPU emulator boot for CPU on the 4-core runner (the BullMQ
+          # extraction worker + its redis polling churn was a plausible cause of
+          # intermittent emulator boot timeouts). The e2e flows never exercise
+          # knowledge-extraction. (CLAUDE.md Stryker gotcha — same flags.)
+          EXTRACTION_WORKER_ENABLED: 'false'
           # Real LLM for the chat shard flows (guardrail/off-topic/multiturn).
           # Same secret ci-cd-backend.yml + promptfoo use. The auth/museum/
           # settings shards never hit the LLM, so spend stays near zero there.
@@ -462,7 +468,7 @@ jobs:
           target: google_apis
           profile: pixel_6
           force-avd-creation: false
-          emulator-boot-timeout: 600
+          emulator-boot-timeout: 300
           ram-size: 4096M
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -479,7 +485,7 @@ jobs:
           target: google_apis
           profile: pixel_6
           force-avd-creation: true
-          emulator-boot-timeout: 600
+          emulator-boot-timeout: 300
           ram-size: 4096M
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -517,7 +523,7 @@ jobs:
     # E41 — runs whenever the shard matrix runs: per-PR (the new guard rail),
     # nightly cron, and manual dispatch. `always()` so a failed shard still
     # gets summarized + turns this aggregator red (anti-false-green).
-    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
     needs: maestro-shard
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -569,6 +575,47 @@ jobs:
         run: |
           echo "::error::Maestro e2e did not pass (maestro-shard result: ${{ needs.maestro-shard.result }}). A green maestro-summary now REQUIRES every shard to succeed."
           exit 1
+
+  # ─── 4b. Nightly / push-main alert — make a red FULL run impossible to miss ─
+  # A scheduled (or push-to-main) full Maestro run executes unattended; a silent
+  # red is a dead gate. On failure this opens (or re-pings) a tracking issue via
+  # the native GITHUB_TOKEN — the repo owner gets a GitHub notification and the
+  # issue stays visible in the Issues tab until fixed. On a green full run it
+  # auto-closes the issue. No external secret/webhook needed.
+  maestro-full-alert:
+    if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    needs: [maestro-shard, maestro-summary]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open/close the full-Maestro tracking issue
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const failed = ${{ needs.maestro-shard.result != 'success' || needs.maestro-summary.result != 'success' }};
+            const { owner, repo } = context.repo;
+            const label = 'nightly-maestro-alert';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const trigger = context.eventName === 'schedule' ? 'nightly' : 'push to main';
+            const existing = await github.rest.issues.listForRepo({ owner, repo, state: 'open', labels: label });
+            if (failed) {
+              const body = `The full Maestro suite failed on a **${trigger}** run.\n\nRun: ${runUrl}\n\nThis issue auto-closes when the next full Maestro run is green.`;
+              if (existing.data.length > 0) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: existing.data[0].number, body: `Still failing (${trigger}) — ${runUrl}` });
+              } else {
+                try { await github.rest.issues.getLabel({ owner, repo, name: label }); }
+                catch { await github.rest.issues.createLabel({ owner, repo, name: label, color: 'b60205', description: 'Auto-filed when a full Maestro run fails' }); }
+                await github.rest.issues.create({ owner, repo, title: `🌙 Full Maestro failing (${trigger})`, body, labels: [label] });
+              }
+            } else {
+              for (const issue of existing.data) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: `✅ Full Maestro green again — ${runUrl}. Closing.` });
+                await github.rest.issues.update({ owner, repo, issue_number: issue.number, state: 'closed' });
+              }
+            }
 
   # ─── 5. iOS nightly Maestro suite (cron-only) ───────────────────────────
   maestro-ios-nightly:

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -420,43 +420,52 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run Maestro shard on Android emulator
+      # E41 — emulator-boot retry. The AVD boot is intermittently flaky on hosted
+      # runners ("Timeout waiting for emulator to boot"): the IDENTICAL config
+      # booted in 49s on some runs and timed out on others (pure runner-side
+      # flake, not config). A single retry takes the per-run flake probability
+      # from ~p to ~p². Attempt 1 is `continue-on-error`; attempt 2 only runs if
+      # attempt 1 failed, and IT decides the job outcome. The in-emulator work is
+      # a single committed script (maestro-emulator-script.sh) so the action runs
+      # it as ONE line — normal shell state persists, and the two attempts share
+      # one definition. Per-flow retries live inside maestro-run-shard.sh; this
+      # outer retry exists for the boot itself.
+      - name: Run Maestro shard on Android emulator (attempt 1)
+        id: maestro_attempt1
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed  # v2
         env:
           MATRIX_SHARD: ${{ matrix.shard }}
         with:
           api-level: 33
           # ubuntu-latest is x86_64 + KVM → x86_64 system image runs natively
-          # accelerated (the whole point of the macos→ubuntu migration). The
-          # prebuild APK is built x86_64-only (-PreactNativeArchitectures), so
-          # its ABI matches this emulator exactly.
+          # accelerated. The prebuild APK is x86_64-only, matching this emulator.
           arch: x86_64
           target: google_apis
           profile: pixel_6
           force-avd-creation: false
-          # E41 — boot reliability: a prior run hit "Timeout waiting for emulator
-          # to boot" (the same config booted in 49s the run before — hosted-runner
-          # flakiness). Raise the boot timeout to 15min and give the AVD more
-          # RAM/cores. `-no-snapshot` forces a clean cold boot every run (no
-          # snapshot load/save), which avoids corrupt-snapshot boot hangs.
-          emulator-boot-timeout: 900
+          emulator-boot-timeout: 600
           ram-size: 4096M
-          cores: 3
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # E41 — the runner executes each script LINE in its own shell (a
-          # `cd` does NOT persist to the next line), so use repo-root-relative
-          # paths and self-contained one-liners (no multi-line `if` block, no
-          # reliance on the exec bit → `bash <script>`). The APK was downloaded
-          # to museum-frontend/android/app/build/outputs/apk/release/.
-          # The fixture push is a harmless no-op on the auth shard (|| true);
-          # maestro-run-shard.sh resolves .maestro/ from its own path, so it
-          # works regardless of cwd.
-          script: |
-            adb install -r museum-frontend/android/app/build/outputs/apk/release/app-release.apk
-            adb push museum-frontend/.maestro/fixtures/test-artwork.jpg /sdcard/Download/test-artwork.jpg || true
-            adb shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Download/test-artwork.jpg || true
-            bash museum-frontend/scripts/maestro-run-shard.sh "$MATRIX_SHARD"
+          script: bash museum-frontend/scripts/maestro-emulator-script.sh "$MATRIX_SHARD"
+
+      - name: Run Maestro shard on Android emulator (attempt 2, retry on attempt-1 failure)
+        if: steps.maestro_attempt1.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed  # v2
+        env:
+          MATRIX_SHARD: ${{ matrix.shard }}
+        with:
+          api-level: 33
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          force-avd-creation: true
+          emulator-boot-timeout: 600
+          ram-size: 4096M
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: bash museum-frontend/scripts/maestro-emulator-script.sh "$MATRIX_SHARD"
 
       - name: Upload shard logs
         if: always()

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -305,7 +305,10 @@ jobs:
           EVENT: ${{ github.event_name }}
         run: |
           if [ "$EVENT" = "pull_request" ]; then
-            echo 'shards=["smoke"]' >> "$GITHUB_OUTPUT"
+            # ITERATION (backlog chat/museum/settings Android remediation): run the
+            # three not-yet-validated shards in parallel on PR to collect failures.
+            # Revert to ["smoke"] before merging.
+            echo 'shards=["chat","museum","settings"]' >> "$GITHUB_OUTPUT"
           else
             echo 'shards=["auth","chat","museum","settings"]' >> "$GITHUB_OUTPUT"
           fi
@@ -497,6 +500,10 @@ jobs:
         with:
           name: maestro-shard-${{ matrix.shard }}-logs
           path: museum-frontend/.maestro/logs/
+          # Maestro writes its per-flow hierarchy/screenshots under a hidden
+          # `.maestro/tests/` dir; upload-artifact@v4 skips hidden files by
+          # default, so opt in to capture them.
+          include-hidden-files: true
           retention-days: 7
 
       # Diagnostics for failing flows: the backend log carries the exact HTTP

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -434,7 +434,15 @@ jobs:
           target: google_apis
           profile: pixel_6
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # E41 — boot reliability: a prior run hit "Timeout waiting for emulator
+          # to boot" (the same config booted in 49s the run before — hosted-runner
+          # flakiness). Raise the boot timeout to 15min and give the AVD more
+          # RAM/cores. `-no-snapshot` forces a clean cold boot every run (no
+          # snapshot load/save), which avoids corrupt-snapshot boot hangs.
+          emulator-boot-timeout: 900
+          ram-size: 4096M
+          cores: 3
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           # E41 — the runner executes each script LINE in its own shell (a
           # `cd` does NOT persist to the next line), so use repo-root-relative

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -458,6 +458,25 @@ jobs:
           path: museum-frontend/.maestro/logs/
           retention-days: 7
 
+      # Diagnostics for failing flows: the backend log carries the exact HTTP
+      # response of each register/login attempt (201 vs 409/422/500), and
+      # Maestro's debug dir (~/.maestro/tests/<ts>/) carries the view hierarchy
+      # + screenshot of the screen the app was actually on when an assertion
+      # failed. Collected into one dir so a single artifact has both.
+      - name: Collect failure diagnostics (backend log + Maestro hierarchy)
+        if: always()
+        run: |
+          mkdir -p /tmp/diag
+          cp /tmp/backend.log /tmp/diag/backend.log 2>/dev/null || true
+          cp -r "$HOME/.maestro/tests" /tmp/diag/maestro-tests 2>/dev/null || true
+      - name: Upload failure diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: maestro-shard-${{ matrix.shard }}-diag
+          path: /tmp/diag/
+          retention-days: 7
+
   # ─── 4. Aggregate shard results into a PR comment ─────────────────────────
   maestro-summary:
     # E41 — runs whenever the shard matrix runs: per-PR (the new guard rail),

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -299,7 +299,11 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     needs: prebuild
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # E41 — 50min: the first full auth shard (18 flows) was cancelled at the old
+    # 30min cap mid-flow-14. Each flow is ~2-2.5min wall (emulator UI + backend
+    # round-trips). Shards run in parallel, so per-PR wall-clock is one shard,
+    # not the sum.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -396,12 +400,18 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           ./scripts/maestro-runner-setup.sh
-          # Seed the FIXED Maestro login account (quick-login.yaml expects
-          # e2e-test-login@test.musaium.dev / TestPassword123!). Direct DB
-          # insert — bypasses the HTTP register breach-check.
+          # Seed the two FIXED Maestro login accounts (direct DB insert, bypasses
+          # the HTTP register breach-check):
+          #   1. e2e-test-login@test.musaium.dev / TestPassword123! — quick-login.yaml
+          #   2. apple.test@apple.com / Apple1234! — auth-login-happy, auth-account-delete,
+          #      cert-pinning-smoke (the Apple-review fixed account).
           cd ../museum-backend
           E2E_SEED_ALLOW=1 DB_HOST=localhost DB_PORT=5432 DB_USER=museum_dev \
             DB_PASSWORD=museum_dev_password PGDATABASE=museum_dev \
+            pnpm seed:e2e-maestro-account
+          E2E_SEED_ALLOW=1 DB_HOST=localhost DB_PORT=5432 DB_USER=museum_dev \
+            DB_PASSWORD=museum_dev_password PGDATABASE=museum_dev \
+            E2E_LOGIN_EMAIL=apple.test@apple.com E2E_LOGIN_PASSWORD='Apple1234!' \
             pnpm seed:e2e-maestro-account
 
       - name: Enable KVM (hardware-accelerated emulator)

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -418,26 +418,27 @@ jobs:
           api-level: 33
           # ubuntu-latest is x86_64 + KVM → x86_64 system image runs natively
           # accelerated (the whole point of the macos→ubuntu migration). The
-          # Release APK from prebuild contains the x86_64 ABI (RN/Hermes builds
-          # all four ABIs by default).
+          # prebuild APK is built x86_64-only (-PreactNativeArchitectures), so
+          # its ABI matches this emulator exactly.
           arch: x86_64
           target: google_apis
           profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          # E41 — the runner executes each script LINE in its own shell (a
+          # `cd` does NOT persist to the next line), so use repo-root-relative
+          # paths and self-contained one-liners (no multi-line `if` block, no
+          # reliance on the exec bit → `bash <script>`). The APK was downloaded
+          # to museum-frontend/android/app/build/outputs/apk/release/.
+          # The fixture push is a harmless no-op on the auth shard (|| true);
+          # maestro-run-shard.sh resolves .maestro/ from its own path, so it
+          # works regardless of cwd.
           script: |
-            cd museum-frontend
-            adb install -r android/app/build/outputs/apk/release/app-release.apk
-            # T9.x — Push the chat-compare fixture into /sdcard/Download/ so
-            # the picker surfaces it as the most-recent local asset. Harmless
-            # on the other shards; pushing is cheap (≤25KB) and idempotent.
-            if [ -f .maestro/fixtures/test-artwork.jpg ]; then
-              adb push .maestro/fixtures/test-artwork.jpg /sdcard/Download/test-artwork.jpg
-              # Tell MediaStore the new file exists so it appears in pickers.
-              adb shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Download/test-artwork.jpg || true
-            fi
-            ./scripts/maestro-run-shard.sh "$MATRIX_SHARD"
+            adb install -r museum-frontend/android/app/build/outputs/apk/release/app-release.apk
+            adb push museum-frontend/.maestro/fixtures/test-artwork.jpg /sdcard/Download/test-artwork.jpg || true
+            adb shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Download/test-artwork.jpg || true
+            bash museum-frontend/scripts/maestro-run-shard.sh "$MATRIX_SHARD"
 
       - name: Upload shard logs
         if: always()

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -42,12 +42,10 @@ on:
       - 'museum-backend/openapi/**'
       - '.github/workflows/ci-cd-mobile.yml'
   schedule:
-    # E39 — Nightly Maestro Android matrix at 03:17 UTC (matches the existing
-    # iOS nightly slot). PR/push only run quality + prebuild for fast feedback;
-    # the slow emulator path is gated to nightly + manual dispatch because
-    # GitHub macos-latest hosted runners can't expose Hypervisor Framework
-    # (HVF_UNSUPPORTED), so arm64 AVDs run software-only and time out at 600s.
-    # Future: self-hosted Mac runner with HVF would enable per-PR maestro.
+    # Nightly slot at 03:17 UTC. Since E41 (ubuntu-latest + KVM) the Android
+    # Maestro matrix runs PER-PR, so this cron is mainly the iOS nightly suite
+    # (maestro-ios-nightly, macos-latest) plus a full-matrix Android re-run as a
+    # backstop against per-PR flakiness.
     - cron: '17 3 * * *'
 
 concurrency:
@@ -173,17 +171,39 @@ jobs:
   # ─── 2. Maestro APK prebuild (cached on mobile-source content hash) ──────
   prebuild:
     needs: quality
-    runs-on: macos-latest
+    # Android builds need no macOS — moved off macos-latest (10× minute cost)
+    # to ubuntu-latest. The Maestro emulator job is now also Linux (KVM), so the
+    # whole Android e2e path is x86_64 + hardware-accelerated.
+    runs-on: ubuntu-latest
     # E17: gradle/actions/setup-gradle caches ~/.gradle/caches + wrapper across
     # runs, so cold first run still ~30 min, warm runs ~3-5 min.
     # E34: bumped 25 → 35 after run 25508936326 hit the 25min cap on the cold
-    # path with the new 6GB heap (heap fixed OOM but D8 :app:mergeExtDexDebug
-    # still wants ~18-22 min wall on cold cache for 4 ABIs). Warm cache stays
-    # well under 5 min, so this only widens the cold-path budget.
+    # path with the new 6GB heap (heap fixed OOM but D8 :app:mergeExtDexRelease
+    # still wants ~18-22 min wall on cold cache). Warm cache stays well under
+    # 5 min, so this only widens the cold-path budget.
     timeout-minutes: 35
     defaults:
       run:
         working-directory: museum-frontend
+    # E40 — Build a RELEASE APK of the `development` variant, NOT assembleDebug.
+    #   * A Debug APK expects a Metro dev server on :8081 (it never embeds the JS
+    #     bundle) → on a CI emulator with no Metro it shows the RN red error
+    #     screen — the Android equivalent of the iOS expo-dev-client launcher
+    #     that made the local e2e suite 0/43 false-green. assembleRelease runs
+    #     `bundleReleaseJsAndAssets` → JS is embedded → standalone, no launcher.
+    #   * APP_VARIANT=development keeps Android cleartext HTTP allowed
+    #     (app.config.ts `usesCleartextTraffic: variant === 'development'` +
+    #     plugins/withNetworkSecurity DEV_XML whitelists 10.0.2.2 / localhost),
+    #     which a Release of preview/production would block.
+    #   * On the Android emulator, the host runner is reachable at 10.0.2.2, NOT
+    #     localhost (that is the emulator's own loopback). EXPO_PUBLIC_* vars are
+    #     inlined into the JS bundle at assembleRelease time, so they MUST be set
+    #     on this job (apiConfig.ts reads process.env.EXPO_PUBLIC_API_BASE_URL
+    #     then Constants.expoConfig.extra.API_BASE_URL — both baked here).
+    env:
+      APP_VARIANT: development
+      EXPO_PUBLIC_API_ENVIRONMENT: staging
+      EXPO_PUBLIC_API_BASE_URL: http://10.0.2.2:3000
     outputs:
       cache-hit: ${{ steps.cache-apk.outputs.cache-hit }}
     steps:
@@ -199,10 +219,14 @@ jobs:
         id: cache-apk
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
-          path: museum-frontend/android/app/build/outputs/apk/debug/app-debug.apk
-          key: maestro-apk-${{ runner.os }}-${{ hashFiles('museum-frontend/src/**', 'museum-frontend/features/**', 'museum-frontend/shared/**', 'museum-frontend/app/**', 'museum-frontend/assets/**', 'museum-frontend/app.config.ts', 'museum-frontend/package.json', 'museum-frontend/package-lock.json') }}
+          path: museum-frontend/android/app/build/outputs/apk/release/app-release.apk
+          # `release-v2` namespace so any stale Debug APK cached under the old
+          # `maestro-apk-<os>-` key (different content) can never be restored.
+          # The 10.0.2.2 base URL is baked into the bundle, so it is part of the
+          # cache identity via app.config.ts in the hash set.
+          key: maestro-apk-release-v2-${{ runner.os }}-${{ hashFiles('museum-frontend/src/**', 'museum-frontend/features/**', 'museum-frontend/shared/**', 'museum-frontend/app/**', 'museum-frontend/assets/**', 'museum-frontend/app.config.ts', 'museum-frontend/plugins/**', 'museum-frontend/package.json', 'museum-frontend/package-lock.json') }}
           restore-keys: |
-            maestro-apk-${{ runner.os }}-
+            maestro-apk-release-v2-${{ runner.os }}-
 
       - name: Setup Java (cache miss only)
         if: steps.cache-apk.outputs.cache-hit != 'true'
@@ -223,7 +247,7 @@ jobs:
         # E17: caches ~/.gradle/caches/modules-2 (~1-2 GB) + ~/.gradle/wrapper
         # (~150 MB) keyed on **/*.gradle*, **/gradle-wrapper.properties.
         # First run still cold (writes cache); subsequent cold-source runs warm-
-        # restore in ~30s, cutting Gradle assembleDebug from ~35min → ~5min.
+        # restore in ~30s, cutting Gradle assembleRelease from ~35min → ~5min.
         # GRADLE_ENCRYPTION_KEY secret would encrypt the cache; left out for
         # now (works unencrypted) — future hardening when secret is provisioned.
         if: steps.cache-apk.outputs.cache-hit != 'true'
@@ -232,40 +256,80 @@ jobs:
           cache-read-only: false
           build-root-directory: museum-frontend/android
 
-      - name: Gradle assembleDebug (cache miss only)
+      - name: Gradle assembleRelease (cache miss only)
         if: steps.cache-apk.outputs.cache-hit != 'true'
-        # `--stacktrace --info` surfaces the actual D8 dex-merge conflict (which
-        # class / dex archive). Without them the previous run died with an
-        # empty `DexArchiveMergerException: Error while merging dex archives:`
-        # message and we couldn't pinpoint the offending dependency. The flags
-        # add a few seconds to the log; harmless for a 5-min cached path.
-        run: cd android && ./gradlew assembleDebug --no-daemon --stacktrace --info
+        # Expo's generated android/app/build.gradle signs the `release` buildType
+        # with the debug keystore when no upload keystore is configured, so this
+        # produces a self-signed but installable APK — sufficient for `adb
+        # install` on the CI emulator (no Play upload). `--stacktrace --info`
+        # surfaces any D8 dex-merge conflict on the cold path.
+        run: cd android && ./gradlew assembleRelease --no-daemon --stacktrace --info
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: preview-apk
-          path: museum-frontend/android/app/build/outputs/apk/debug/app-debug.apk
+          name: maestro-apk
+          path: museum-frontend/android/app/build/outputs/apk/release/app-release.apk
           retention-days: 1
 
-  # ─── 3. Maestro shard matrix (Android, nightly cron + manual dispatch) ───
-  # E39 — gated off PR/push because hosted macos-latest runners can't run the
-  # arm64 emulator (HVF unavailable). Re-enable per-PR when a self-hosted Mac
-  # runner is provisioned.
+  # ─── 3. Maestro shard matrix (Android, ubuntu-latest + KVM emulator) ─────
+  # E41 — migrated off macos-latest. GitHub's hosted ubuntu-latest runners
+  # expose /dev/kvm (nested hardware virtualization), so an x86_64 AVD runs
+  # HW-accelerated and boots in ~60-90s instead of timing out at 600s under
+  # macos-latest's software-only arm64 path (HVF unavailable on hosted Macs).
+  # This unlocks per-PR Maestro: the job now also runs on pull_request, turning
+  # the local-green Maestro suite into a permanent CI guard rail (UFR-021) and
+  # closing the CNIL age-15 e2e blocker. iOS Maestro stays nightly (see
+  # maestro-ios-nightly) — HVF on iOS needs a self-hosted Mac runner.
   maestro-shard:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     needs: prebuild
-    runs-on: macos-latest
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        shard: [auth, chat, museum, settings]
+        # ITERATION: temporarily reduced to the auth canary while the ubuntu
+        # KVM pipeline is being proven (emulator boot + backend@10.0.2.2 + APK
+        # install + login). Expanded back to [auth, chat, museum, settings]
+        # once auth is runtime-green on real CI.
+        shard: [auth]
     defaults:
       run:
         working-directory: museum-frontend
     env:
       MAESTRO_VERSION: '2.5.1'
+    # GHA service containers (mirror ci-cd-backend.yml + the docker-compose.dev
+    # contract). pgvector/pgvector:pg16 because migration AddArtworkEmbeddings
+    # runs `CREATE EXTENSION vector` (halfvec) — plain postgres:16 aborts the
+    # migration and the backend never boots. redis:7-alpine because `pnpm dev`
+    # eagerly boots BullMQ → without Redis, /api/health times out and every
+    # shard dies at setup (the real reason the old macos native-PG path was
+    # false-green: it had no Redis). No requirepass here (the host `pnpm dev`
+    # connects password-less), matching ci-cd-backend.yml's redis service.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: museum_dev
+          POSTGRES_PASSWORD: museum_dev_password
+          POSTGRES_DB: museum_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U museum_dev -d museum_dev"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Setup Node
@@ -283,11 +347,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Download APK artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: preview-apk
-          path: museum-frontend/android/app/build/outputs/apk/debug/
+          name: maestro-apk
+          path: museum-frontend/android/app/build/outputs/apk/release/
 
       - name: Install Maestro CLI
         run: |
@@ -296,44 +362,33 @@ jobs:
       - name: Verify Maestro version
         run: maestro --version
 
-      - name: Install + start native Postgres (E37bis — macos-latest has no Docker, Colima/VZ fails on hosted M1)
-        # E37 (Colima) failed because the macos-latest hosted M1 runner can't
-        # nest the VZ driver. Switching to native Homebrew Postgres avoids the
-        # VM entirely and is faster (no boot, ~10s readiness).
-        run: |
-          brew install --quiet postgresql@16
-          # pgvector >=0.7.0 — AddArtworkEmbeddings runs `CREATE EXTENSION vector`
-          # (halfvec). Homebrew postgresql@16 does NOT bundle pgvector, so the
-          # migration aborts and the backend never boots (all Maestro shards die at
-          # setup). Build pgvector from source against pg16's pg_config so
-          # vector.control lands in pg16's extension dir. (CLAUDE.md gotcha:
-          # "migration:run fait CREATE EXTENSION vector → Postgres MUST have pgvector".)
-          PG16_BIN=/opt/homebrew/opt/postgresql@16/bin
-          git clone --depth 1 --branch v0.8.0 https://github.com/pgvector/pgvector.git /tmp/pgvector
-          make -C /tmp/pgvector PG_CONFIG="$PG16_BIN/pg_config"
-          make -C /tmp/pgvector PG_CONFIG="$PG16_BIN/pg_config" install
-          brew services start postgresql@16
-          # Wait for pg_isready, then create the role + database the BE expects
-          # shellcheck disable=SC2034  # loop counter is intentional; body uses break/sleep, not $i
-          for i in $(seq 1 30); do
-            if /opt/homebrew/opt/postgresql@16/bin/pg_isready -h localhost -p 5432 > /dev/null 2>&1; then
-              break
-            fi
-            sleep 1
-          done
-          /opt/homebrew/opt/postgresql@16/bin/createuser -s museum_dev || true
-          /opt/homebrew/opt/postgresql@16/bin/psql -d postgres -c "ALTER USER museum_dev WITH PASSWORD 'museum_dev_password';"
-          /opt/homebrew/opt/postgresql@16/bin/createdb -O museum_dev museum_dev || true
-
-      - name: Boot backend (native PG + migrations + API)
+      - name: Boot backend (PG/Redis services + migrations + API + e2e seed)
         working-directory: museum-frontend
         env:
+          # Host `pnpm dev` talks to the GHA service containers on localhost.
           SKIP_DOCKER_COMPOSE: '1'
+          DB_HOST: localhost
           DB_PORT: '5432'
-        run: ./scripts/maestro-runner-setup.sh
+          DB_USER: museum_dev
+          DB_PASSWORD: museum_dev_password
+          PGDATABASE: museum_dev
+          REDIS_HOST: localhost
+          REDIS_PORT: '6379'
+          # Real LLM for the chat shard flows (guardrail/off-topic/multiturn).
+          # Same secret ci-cd-backend.yml + promptfoo use. The auth/museum/
+          # settings shards never hit the LLM, so spend stays near zero there.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          ./scripts/maestro-runner-setup.sh
+          # Seed the FIXED Maestro login account (quick-login.yaml expects
+          # e2e-test-login@test.musaium.dev / TestPassword123!). Direct DB
+          # insert — bypasses the HTTP register breach-check.
+          cd ../museum-backend
+          E2E_SEED_ALLOW=1 DB_HOST=localhost DB_PORT=5432 DB_USER=museum_dev \
+            DB_PASSWORD=museum_dev_password PGDATABASE=museum_dev \
+            pnpm seed:e2e-maestro-account
 
-      - name: Enable KVM (for hardware-accelerated emulator)
-        if: runner.os == 'Linux'
+      - name: Enable KVM (hardware-accelerated emulator)
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
@@ -341,12 +396,15 @@ jobs:
 
       - name: Run Maestro shard on Android emulator
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed  # v2
+        env:
+          MATRIX_SHARD: ${{ matrix.shard }}
         with:
           api-level: 33
-          # E38 — macos-latest hosted runner is arm64 (M1); QEMU2 cannot
-          # emulate x86_64 AVDs on an aarch64 host. Switch to arm64-v8a
-          # system image (matching APK ABI built in prebuild).
-          arch: arm64-v8a
+          # ubuntu-latest is x86_64 + KVM → x86_64 system image runs natively
+          # accelerated (the whole point of the macos→ubuntu migration). The
+          # Release APK from prebuild contains the x86_64 ABI (RN/Hermes builds
+          # all four ABIs by default).
+          arch: x86_64
           target: google_apis
           profile: pixel_6
           force-avd-creation: false
@@ -354,7 +412,7 @@ jobs:
           disable-animations: true
           script: |
             cd museum-frontend
-            adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+            adb install -r android/app/build/outputs/apk/release/app-release.apk
             # T9.x — Push the chat-compare fixture into /sdcard/Download/ so
             # the picker surfaces it as the most-recent local asset. Harmless
             # on the other shards; pushing is cheap (≤25KB) and idempotent.
@@ -363,7 +421,7 @@ jobs:
               # Tell MediaStore the new file exists so it appears in pickers.
               adb shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Download/test-artwork.jpg || true
             fi
-            ./scripts/maestro-run-shard.sh ${{ matrix.shard }}
+            ./scripts/maestro-run-shard.sh "$MATRIX_SHARD"
 
       - name: Upload shard logs
         if: always()
@@ -375,10 +433,10 @@ jobs:
 
   # ─── 4. Aggregate shard results into a PR comment ─────────────────────────
   maestro-summary:
-    # E39 — only PR runs ever produced shard logs to summarize, but PR no
-    # longer runs maestro-shard. Keep gate consistent — runs only when the
-    # shard matrix above runs (nightly cron + dispatch).
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    # E41 — runs whenever the shard matrix runs: per-PR (the new guard rail),
+    # nightly cron, and manual dispatch. `always()` so a failed shard still
+    # gets summarized + turns this aggregator red (anti-false-green).
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     needs: maestro-shard
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -286,32 +286,50 @@ jobs:
           path: museum-frontend/android/app/build/outputs/apk/release/app-release.apk
           retention-days: 1
 
-  # ─── 3. Maestro shard matrix (Android, ubuntu-latest + KVM emulator) ─────
+  # ─── 3a. Maestro matrix selector ─────────────────────────────────────────
+  # Per-PR runs only the fast `smoke` subset (~12min, one emulator boot); the
+  # full per-shard suite runs nightly (cron) + on manual dispatch. Emulator e2e
+  # is ~45min/shard, so running all four shards on every PR (~50-65min) is too
+  # heavy — smoke gives a fast pre-merge guard rail on the critical happy paths
+  # while nightly keeps full coverage.
+  maestro-matrix:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      shards: ${{ steps.set.outputs.shards }}
+    steps:
+      - id: set
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT" = "pull_request" ]; then
+            echo 'shards=["smoke"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'shards=["auth","chat","museum","settings"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─── 3b. Maestro shard matrix (Android, ubuntu-latest + KVM emulator) ─────
   # E41 — migrated off macos-latest. GitHub's hosted ubuntu-latest runners
   # expose /dev/kvm (nested hardware virtualization), so an x86_64 AVD runs
   # HW-accelerated and boots in ~60-90s instead of timing out at 600s under
   # macos-latest's software-only arm64 path (HVF unavailable on hosted Macs).
-  # This unlocks per-PR Maestro: the job now also runs on pull_request, turning
-  # the local-green Maestro suite into a permanent CI guard rail (UFR-021) and
-  # closing the CNIL age-15 e2e blocker. iOS Maestro stays nightly (see
-  # maestro-ios-nightly) — HVF on iOS needs a self-hosted Mac runner.
+  # This unlocks per-PR Maestro (smoke subset), turning the local-green Maestro
+  # suite into a permanent CI guard rail (UFR-021) and closing the CNIL age-15
+  # e2e blocker. iOS Maestro stays nightly — HVF on iOS needs a Mac runner.
   maestro-shard:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    needs: prebuild
+    needs: [prebuild, maestro-matrix]
     runs-on: ubuntu-latest
-    # E41 — 50min: the first full auth shard (18 flows) was cancelled at the old
-    # 30min cap mid-flow-14. Each flow is ~2-2.5min wall (emulator UI + backend
-    # round-trips). Shards run in parallel, so per-PR wall-clock is one shard,
-    # not the sum.
-    timeout-minutes: 50
+    # 70min cap: a nightly full shard (~45min, 18 flows × ~2.5min) plus a
+    # boot-flake retry (attempt 1 timeout + attempt 2 full) must fit. The per-PR
+    # smoke shard finishes in ~12-25min and never approaches this cap.
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:
-        # ITERATION: temporarily reduced to the auth canary while the ubuntu
-        # KVM pipeline is being proven (emulator boot + backend@10.0.2.2 + APK
-        # install + login). Expanded back to [auth, chat, museum, settings]
-        # once auth is runtime-green on real CI.
-        shard: [auth]
+        shard: ${{ fromJSON(needs.maestro-matrix.outputs.shards) }}
     defaults:
       run:
         working-directory: museum-frontend

--- a/.github/workflows/ci-cd-mobile.yml
+++ b/.github/workflows/ci-cd-mobile.yml
@@ -204,6 +204,10 @@ jobs:
       APP_VARIANT: development
       EXPO_PUBLIC_API_ENVIRONMENT: staging
       EXPO_PUBLIC_API_BASE_URL: http://10.0.2.2:3000
+      # @sentry/react-native's gradle integration auto-uploads JS sourcemaps on
+      # RELEASE builds and needs SENTRY_AUTH_TOKEN (absent here). Disable it: the
+      # Maestro APK only runs on the CI emulator and is never shipped.
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     outputs:
       cache-hit: ${{ steps.cache-apk.outputs.cache-hit }}
     steps:
@@ -254,16 +258,26 @@ jobs:
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a  # v4.4.3
         with:
           cache-read-only: false
-          build-root-directory: museum-frontend/android
+          # NOTE: `build-root-directory` is NOT a valid input for
+          # gradle/actions/setup-gradle@v4 (it warned + was ignored). The action
+          # caches ~/.gradle regardless of the project root, and the build runs
+          # from museum-frontend/android via `cd android` below.
 
       - name: Gradle assembleRelease (cache miss only)
         if: steps.cache-apk.outputs.cache-hit != 'true'
         # Expo's generated android/app/build.gradle signs the `release` buildType
         # with the debug keystore when no upload keystore is configured, so this
         # produces a self-signed but installable APK — sufficient for `adb
-        # install` on the CI emulator (no Play upload). `--stacktrace --info`
-        # surfaces any D8 dex-merge conflict on the cold path.
-        run: cd android && ./gradlew assembleRelease --no-daemon --stacktrace --info
+        # install` on the CI emulator (no Play upload).
+        #
+        # E41 — `-PreactNativeArchitectures=x86_64`: the CI emulator is x86_64,
+        # so build ONLY that ABI instead of the default 4 (armeabi-v7a, arm64-v8a,
+        # x86, x86_64). Quarters the native build's time/disk/RAM and removes the
+        # most likely cause of the silent process kill on the first run (the
+        # 4-ABI cold build at 25% config exhausted runner resources with no
+        # graceful Gradle error). `--info` dropped — it produced 23k lines that
+        # buried the real failure; `--stacktrace` alone surfaces a clean error.
+        run: cd android && ./gradlew assembleRelease --no-daemon --stacktrace -PreactNativeArchitectures=x86_64
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ pnpm build                       # build design tokens → museum-frontend/share
 GitHub Actions workflows (`.github/workflows/`):
 - `ci-cd-backend.yml` — quality gate (tsc + ESLint + tests + OpenAPI validate + audit) → E2E (PR/nightly) → deploy prod (push main) / staging (push staging) w/ Trivy + Sentry + smoke
 - `ci-cd-web.yml` — quality (lint + build + test + audit) → Lighthouse CI (PR) → deploy Docker/GHCR → VPS
-- `ci-cd-mobile.yml` — quality (Expo Doctor + OpenAPI sync + audit + i18n + lint + tests + shard-manifest sentinel) → Maestro Android matrix (4 shards) + iOS nightly cron → EAS build + store submit
+- `ci-cd-mobile.yml` — quality (Expo Doctor + OpenAPI sync + audit + i18n + lint + tests + shard-manifest sentinel) → Maestro Android e2e on **ubuntu-latest + KVM** (x86_64 emulator, backend via GHA pgvector/redis services, Release APK) → EAS build + store submit. **Per-PR = `smoke` subset (~12min, 1 emulator boot); full 4-shard suite runs nightly cron + on push to `main`.** A red full run auto-files a GitHub issue (`maestro-full-alert` job, label `nightly-maestro-alert`) and `node scripts/nightly-status.mjs` surfaces the last full result — **run it at the start of any frontend-touching session** so an unattended red isn't missed. iOS Maestro stays nightly (HVF needs a Mac runner).
 - `deploy-privacy-policy.yml` — privacy policy static page deploy
 - `codeql.yml` — CodeQL security analysis
 - `semgrep.yml` — SAST static analysis

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -691,7 +691,7 @@ Une dette doit être **prouvable par le code** : si le grep ne retourne rien, on
 - [ ] **Statut** : ouvert (créé 2026-05-21, /team run `2026-05-21-p0-c3-auth-crypto` reviewer F6 + run `2026-05-21-p0-c4-infra` documenter sweep)
 - **Référence code** :
   - `museum-backend/src/shared/observability/prometheus-metrics.ts` (cible — fichier registry existant, ajouter 3 counters)
-  - **Counters spécifiés C3 design §10** (`team-state/2026-05-21-p0-c3-auth-crypto/design.md:354-365`) :
+  - **Counters spécifiés C3 design §10** (`team-state/2026-05-21-p0-c3-auth-crypto/design.md` §10, lignes 354-365 — spec team-state archivée/élaguée, récupérable via git history) :
     1. `totp_replay_blocked_total{user_role}` — incrémenté dans `challengeMfa` + `verifyMfa` à chaque rejet pour `step <= lastUsedStep` (I-SEC7a, ferme RFC 6238 §5.2 replay window).
     2. `access_token_revoked_total{source="logout"|"admin"}` — incrémenté à chaque `denylist.add` réussi (I-SEC7b, ADR-064 denylist fail-OPEN).
     3. `art_keywords_rate_limited_total{role}` — incrémenté quand `taxonomyWriteLimiter` rejette (via custom keyGenerator wrapping ou hook `onLimitReached`, I-SEC3).
@@ -1409,7 +1409,7 @@ Runbook : [`docs/operations/UNIVERSAL_LINKS_VERIFICATION.md`](operations/UNIVERS
 - **Référence code** :
   ```
   museum-frontend/__tests__/features/chat/bottom-sheet-router/backdrop-dismiss.test.tsx:163-211 (cases array)
-  team-state/2026-05-23-chat-composer-buttons-modal-dismiss/spec.md:48 (R6 wording "every non-blocking route" → 6 routes)
+  team-state/2026-05-23-chat-composer-buttons-modal-dismiss/spec.md (R6 §48 wording "every non-blocking route" → 6 routes — spec team-state archivée/élaguée, voir git history)
   ```
 - **Symptôme** : la spec R6 demande la parameterisation sur 6 routes non-bloquantes (`attachment-picker`, `browser`, `context-menu`, `summary`, `ai-disclosure`, `cartel-scanner`). Le test couvre 4/6 (`attachment-picker`, `browser`, `context-menu`, `summary`) ; manque `ai-disclosure` + `cartel-scanner`.
 - **Pourquoi non résolu en V1** : (a) test frozen per UFR-022 red-test-manifest ; (b) le fix container-level (`pointerEvents="box-none"` sur `<BottomSheetContainer>`) est *uniforme* sur toutes les routes C4 — un seul `BottomSheetContainer` les héberge → la couverture 4/6 est *fonctionnellement complète proof* que les 6 routes fonctionnent ; (c) re-spawn red phase juste pour étendre l'array `cases` (2-line change) = disproportionné vs le bénéfice ; (d) reviewer loop 2 a explicitement accepté comme INFO non-blocking.

--- a/museum-backend/package.json
+++ b/museum-backend/package.json
@@ -57,6 +57,7 @@
     "seed:kb-canon": "ts-node -r tsconfig-paths/register scripts/seed-kb-canon.ts",
     "seed:kb-canon:host": "bash scripts/with-host-env.sh ts-node -r tsconfig-paths/register scripts/seed-kb-canon.ts",
     "seed:smoke-account": "ts-node -r tsconfig-paths/register scripts/seed-smoke-account.ts",
+    "seed:e2e-maestro-account": "ts-node -r tsconfig-paths/register scripts/seed-e2e-maestro-account.ts",
     "seed:perf": "ts-node -r tsconfig-paths/register scripts/seed-perf-load.ts",
     "prune:retention": "ts-node -r tsconfig-paths/register scripts/prune-retention.ts",
     "audit-chain:verify": "ts-node -r tsconfig-paths/register scripts/audit-chain-verify.ts",

--- a/museum-frontend/.maestro/auth-account-delete.yaml
+++ b/museum-frontend/.maestro/auth-account-delete.yaml
@@ -99,7 +99,7 @@ appId: com.musaium.mobile.preview
 # = "Supprimer le compte définitivement" / "Delete account permanently")
 # COLLAPSES the subtree, so match the a11y label.
 - tapOn:
-    text: "Supprimer le compte définitivement|Delete account permanently"
+    id: "settings-delete-account"
 
 # ──────────────────────────────────────────────
 # Phase 4: Confirm native Alert (settings.delete_confirm_title / _body)

--- a/museum-frontend/.maestro/auth-flow.yaml
+++ b/museum-frontend/.maestro/auth-flow.yaml
@@ -71,7 +71,7 @@ appId: com.musaium.mobile.preview
 # Accept GDPR by tapping the checkbox SQUARE (row left edge); the row center has
 # the inline Terms/Privacy links (own onPress → navigate away).
 - tapOn:
-    point: "11%,67%"
+    id: "gdpr-consent-checkbox"
 
 # Submit (button already on screen; hard scrollUntilVisible@100% fails when no
 # scroll is needed). Wait + tap by testID.

--- a/museum-frontend/.maestro/auth-register-duplicate-email.yaml
+++ b/museum-frontend/.maestro/auth-register-duplicate-email.yaml
@@ -65,7 +65,7 @@ appId: com.musaium.mobile.preview
 # Accept GDPR by tapping the checkbox SQUARE (row left edge). Tapping the row
 # center hits the inline Terms/Privacy links (own onPress → navigate away).
 - tapOn:
-    point: "11%,67%"
+    id: "gdpr-consent-checkbox"
 
 # Submit (button already on screen; a hard scrollUntilVisible@100% fails when no
 # scroll is needed). Wait + tap by testID.

--- a/museum-frontend/.maestro/auth-register-happy.yaml
+++ b/museum-frontend/.maestro/auth-register-happy.yaml
@@ -85,7 +85,7 @@ appId: com.musaium.mobile.preview
 # element by label lands on the center → opens Terms. Tap the checkbox SQUARE at
 # the row's left edge instead (the box is the first ~20px of the row).
 - tapOn:
-    point: "11%,67%"
+    id: "gdpr-consent-checkbox"
 
 # Submit. The button is already on screen on iPhone 17; a hard scrollUntilVisible
 # at 100% visibility fails when no scroll is needed, so wait + tap by testID.

--- a/museum-frontend/.maestro/auth-register-minor-dob.yaml
+++ b/museum-frontend/.maestro/auth-register-minor-dob.yaml
@@ -70,7 +70,7 @@ appId: com.musaium.mobile.preview
 # Accept GDPR by tapping the checkbox SQUARE (row left edge). Tapping the row
 # center hits the inline Terms/Privacy links (own onPress → navigate away).
 - tapOn:
-    point: "11%,67%"
+    id: "gdpr-consent-checkbox"
 
 # Submit (button already on screen; a hard scrollUntilVisible@100% fails when no
 # scroll is needed). Wait + tap by testID.

--- a/museum-frontend/.maestro/auth-register-password-breached.yaml
+++ b/museum-frontend/.maestro/auth-register-password-breached.yaml
@@ -67,7 +67,7 @@ appId: com.musaium.mobile.preview
 # Accept GDPR by tapping the checkbox SQUARE (row left edge). Tapping the row
 # center hits the inline Terms/Privacy links (own onPress → navigate away).
 - tapOn:
-    point: "11%,67%"
+    id: "gdpr-consent-checkbox"
 
 # Submit (button already on screen; a hard scrollUntilVisible@100% fails when no
 # scroll is needed). Wait + tap by testID.

--- a/museum-frontend/.maestro/cert-pinning-smoke.yaml
+++ b/museum-frontend/.maestro/cert-pinning-smoke.yaml
@@ -14,8 +14,8 @@ appId: com.musaium.mobile.preview
 #   - The pin set in `shared/config/cert-pinning.ts` matches the
 #     live `musaium.com:443` chain (otherwise the auth fetch TLS-fails).
 #
-# Test account: seeded smoke account (apple.test@apple.com / Apple1234!)
-# — matches helpers/quick-login.yaml + auth-login-happy.yaml conventions.
+# Test account: stable e2e account (e2e-test-login@test.musaium.dev) — NOT
+# apple.test, which auth-account-delete destructively deletes earlier in the shard.
 #
 # Cited: lib-docs/react-native-ssl-public-key-pinning/PATTERNS.md §5.2
 # lines 127-133 (iOS TLS session cache makes "wrong pin" tests lie).
@@ -38,11 +38,11 @@ appId: com.musaium.mobile.preview
 
 - tapOn:
     id: "email-input"
-- inputText: "apple.test@apple.com"
+- inputText: "e2e-test-login@test.musaium.dev"
 
 - tapOn:
     id: "password-input"
-- inputText: "Apple1234!"
+- inputText: "TestPassword123!"
 
 - hideKeyboard
 

--- a/museum-frontend/.maestro/shards.json
+++ b/museum-frontend/.maestro/shards.json
@@ -34,6 +34,13 @@
         "chat-cartel-deeplink.yaml",
         "connectivity-offline-banner.yaml",
         "consent-location-grant.yaml",
+        "chat-guardrail-insult.yaml",
+        "chat-guardrail-injection.yaml",
+        "chat-offtopic-redirect.yaml",
+        "chat-multiturn-coherence.yaml",
+        "chat-input-very-long.yaml",
+        "chat-input-edge.yaml",
+        "chat-image-describe.yaml",
         "modal-chat-artwork-hero.yaml",
         "modal-chat-image-fullscreen.yaml",
         "modal-chat-source-citation.yaml"

--- a/museum-frontend/.maestro/shards.json
+++ b/museum-frontend/.maestro/shards.json
@@ -72,5 +72,12 @@
     }
   ],
   "iosNightly": "all",
+  "smoke": [
+    "auth-login-happy.yaml",
+    "auth-register-happy.yaml",
+    "auth-persistence.yaml",
+    "onboarding-flow.yaml",
+    "magic-link-verify-email.yaml"
+  ],
   "excluded": ["config.yaml"]
 }

--- a/museum-frontend/features/auth/ui/GdprConsentCheckbox.tsx
+++ b/museum-frontend/features/auth/ui/GdprConsentCheckbox.tsx
@@ -40,6 +40,7 @@ export function GdprConsentCheckbox({
       accessibilityState={{ checked: accepted }}
     >
       <View
+        testID="gdpr-consent-checkbox"
         style={[
           styles.checkbox,
           { borderColor: theme.inputBorder, backgroundColor: theme.inputBackground },

--- a/museum-frontend/features/settings/ui/SettingsDangerZone.tsx
+++ b/museum-frontend/features/settings/ui/SettingsDangerZone.tsx
@@ -25,6 +25,7 @@ export const SettingsDangerZone = ({
         {t('settings.danger_zone_desc')}
       </Text>
       <Pressable
+        testID="settings-delete-account"
         style={[styles.deleteButton, { backgroundColor: theme.danger }]}
         onPress={onDeleteAccount}
         disabled={isDeletingAccount}

--- a/museum-frontend/scripts/maestro-emulator-script.sh
+++ b/museum-frontend/scripts/maestro-emulator-script.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Runs INSIDE the reactivecircus/android-emulator-runner once the AVD has booted.
+# The action invokes this as a single line (`bash …/maestro-emulator-script.sh
+# <shard>`), so — unlike a multi-line inline `script:` where each line runs in
+# its own shell — normal shell state (cwd, vars) persists here.
+#
+# Paths are repo-root-relative: the action's cwd is the workspace root, and the
+# prebuild APK was downloaded to museum-frontend/android/app/build/outputs/apk/.
+set -uo pipefail
+
+SHARD="${1:?usage: maestro-emulator-script.sh <shard>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+adb install -r "$ROOT/museum-frontend/android/app/build/outputs/apk/release/app-release.apk"
+
+# T9.x — push the chat-compare fixture so the picker surfaces it as the most
+# recent local asset. Harmless on shards that don't use it (|| true).
+FIXTURE="$ROOT/museum-frontend/.maestro/fixtures/test-artwork.jpg"
+if [ -f "$FIXTURE" ]; then
+  adb push "$FIXTURE" /sdcard/Download/test-artwork.jpg || true
+  adb shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE \
+    -d file:///sdcard/Download/test-artwork.jpg || true
+fi
+
+bash "$ROOT/museum-frontend/scripts/maestro-run-shard.sh" "$SHARD"

--- a/museum-frontend/scripts/maestro-run-shard.sh
+++ b/museum-frontend/scripts/maestro-run-shard.sh
@@ -40,7 +40,11 @@ echo "$FLOWS"
 while IFS= read -r flow; do
   [ -z "$flow" ] && continue
   echo "[shard:$SHARD] running $flow…"
-  if maestro test "$MAESTRO_DIR/$flow" 2>&1 | tee "$LOG_DIR/${SHARD}-${flow%.yaml}.log"; then
+  # `--debug-output` writes the per-flow view hierarchy + screenshots into
+  # logs/debug/<flow>/, captured by the CI "Upload shard logs" artifact. This is
+  # what lets us see the exact screen the app was on when an assertion failed
+  # (e.g. a register flow landing on a verify-email gate vs onboarding).
+  if maestro test --debug-output "$LOG_DIR/debug/${flow%.yaml}" "$MAESTRO_DIR/$flow" 2>&1 | tee "$LOG_DIR/${SHARD}-${flow%.yaml}.log"; then
     echo "[shard:$SHARD] $flow PASS"
   else
     echo "[shard:$SHARD] $flow FAIL"

--- a/museum-frontend/scripts/maestro-run-shard.sh
+++ b/museum-frontend/scripts/maestro-run-shard.sh
@@ -24,6 +24,12 @@ fi
 
 if [ "$SHARD" = "all" ]; then
   FLOWS=$(jq -r '.shards[].flows[]' "$MAESTRO_DIR/shards.json")
+elif [ "$SHARD" = "smoke" ]; then
+  # Per-PR fast subset: a handful of proven-green critical happy paths run on a
+  # single emulator boot (~12min). The full per-shard suite runs nightly. The
+  # `smoke` list lives OUTSIDE `.shards[]` so its flows (which are also in the
+  # `auth` shard) don't trip the shard-manifest dedup sentinel.
+  FLOWS=$(jq -r '.smoke[]' "$MAESTRO_DIR/shards.json")
 else
   FLOWS=$(jq -r --arg s "$SHARD" '.shards[] | select(.name == $s) | .flows[]' "$MAESTRO_DIR/shards.json")
 fi

--- a/museum-frontend/scripts/maestro-run-shard.sh
+++ b/museum-frontend/scripts/maestro-run-shard.sh
@@ -37,14 +37,30 @@ FAIL_COUNT=0
 echo "[shard:$SHARD] flows to run:"
 echo "$FLOWS"
 
+# Each flow gets one retry before being marked FAIL. Maestro flows on a CI
+# emulator have a transient-flake floor (deep-link mount timing, a dropped first
+# tap right after boot, animation races) that a single re-run clears. Only
+# failures retry, so green flows pay nothing; a genuinely-broken flow runs twice
+# (acceptable — the guard rail must not go red on a one-off flake).
+MAX_ATTEMPTS="${MAESTRO_FLOW_ATTEMPTS:-2}"
+
 while IFS= read -r flow; do
   [ -z "$flow" ] && continue
-  echo "[shard:$SHARD] running $flow…"
-  # `--debug-output` writes the per-flow view hierarchy + screenshots into
-  # logs/debug/<flow>/, captured by the CI "Upload shard logs" artifact. This is
-  # what lets us see the exact screen the app was on when an assertion failed
-  # (e.g. a register flow landing on a verify-email gate vs onboarding).
-  if maestro test --debug-output "$LOG_DIR/debug/${flow%.yaml}" "$MAESTRO_DIR/$flow" 2>&1 | tee "$LOG_DIR/${SHARD}-${flow%.yaml}.log"; then
+  attempt=1
+  passed=0
+  while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+    echo "[shard:$SHARD] running $flow (attempt $attempt/$MAX_ATTEMPTS)…"
+    # `--debug-output` writes the per-flow view hierarchy + screenshots into
+    # logs/debug/<flow>/, captured by the CI "Upload shard logs" artifact — it
+    # shows the exact screen the app was on when an assertion failed.
+    if maestro test --debug-output "$LOG_DIR/debug/${flow%.yaml}" "$MAESTRO_DIR/$flow" 2>&1 | tee "$LOG_DIR/${SHARD}-${flow%.yaml}.log"; then
+      passed=1
+      break
+    fi
+    echo "[shard:$SHARD] $flow attempt $attempt failed"
+    attempt=$((attempt + 1))
+  done
+  if [ "$passed" -eq 1 ]; then
     echo "[shard:$SHARD] $flow PASS"
   else
     echo "[shard:$SHARD] $flow FAIL"

--- a/scripts/nightly-status.mjs
+++ b/scripts/nightly-status.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * nightly-status — surface the last FULL Maestro run (nightly cron OR push-to-main)
+ * so an unattended red full run isn't silently ignored.
+ *
+ * Per-PR CI only runs the fast `smoke` subset (~12min); the full 4-shard suite
+ * runs nightly + on push to main. Run this at the start of any frontend-touching
+ * session (the `mobile` workflow alert job also auto-files a GitHub issue on a
+ * red full run, but this gives an at-a-glance check without leaving the terminal).
+ *
+ * Usage: node scripts/nightly-status.mjs
+ * Exit 0 = green / unknown (non-fatal); exit 1 = the last full run is RED.
+ */
+import { execFileSync } from 'node:child_process';
+
+try {
+  const raw = execFileSync(
+    'gh',
+    [
+      'run',
+      'list',
+      '--workflow',
+      'mobile',
+      '-L',
+      '20',
+      '--json',
+      'event,headBranch,conclusion,status,createdAt,url',
+    ],
+    { encoding: 'utf8' },
+  );
+  const runs = JSON.parse(raw);
+  const full = runs.find(
+    (r) => r.event === 'schedule' || (r.event === 'push' && r.headBranch === 'main'),
+  );
+
+  if (!full) {
+    console.log('nightly-status: no full Maestro run (nightly / push-main) in the last 20 runs yet.');
+    process.exit(0);
+  }
+
+  const done = full.status === 'completed';
+  const concl = full.conclusion || full.status;
+  const icon = concl === 'success' ? '✅' : done ? '❌' : '⏳';
+  console.log(`${icon} Last full Maestro (${full.event}, ${full.createdAt.slice(0, 10)}): ${concl}`);
+  console.log(`   ${full.url}`);
+
+  if (done && concl !== 'success') {
+    console.log('   ⚠️  Full Maestro is RED — config/flows may be broken. Investigate before shipping frontend.');
+    process.exit(1);
+  }
+  process.exit(0);
+} catch (e) {
+  // Non-fatal: gh missing / unauthed / offline must not block a session.
+  console.log(`nightly-status: could not query gh (${String(e.message).split('\n')[0]}).`);
+  process.exit(0);
+}

--- a/scripts/sentinels/doc-last-verified.json
+++ b/scripts/sentinels/doc-last-verified.json
@@ -3,9 +3,9 @@
   "docs": {
     "docs/ROADMAP_PRODUCT.md": "2026-06-01",
     "docs/ARCHITECTURE.md": "2026-05-27",
-    "docs/TECH_DEBT.md": "2026-05-31",
+    "docs/TECH_DEBT.md": "2026-06-01",
     "docs/legal/ROPA.md": "2026-05-31",
-    "docs/compliance/SUBPROCESSORS.md": "2026-05-31",
+    "docs/compliance/SUBPROCESSORS.md": "2026-06-01",
     "SECURITY.md": "2026-05-27",
     "docs/AI_SAFETY.md": "2026-05-31",
     "docs/AI_VOICE.md": "2026-05-31",


### PR DESCRIPTION
Backlog suite to #308 (merged): get the chat/museum/settings Maestro shards green on Android (only auth/smoke validated so far).

This PR temporarily runs the 3 shards in parallel on PR to collect failures, then will batch-fix (testIDs, account state, geo, carve env-blocked flows like chat-compare/SigLIP, audio fixture, dev-routes). Reverts to smoke-per-PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)