### PR TITLE
Post-merge deploy fixes: smoke image-consent + SHA-pinned rollback + ai-tests→guardrail-failclosed

### DIFF
--- a/.github/branch-protection/main.json
+++ b/.github/branch-protection/main.json
@@ -19,7 +19,7 @@
     "strict": true,
     "always": [
       "quality",
-      "ai-tests",
+      "guardrail-failclosed",
       "CodeQL (javascript-typescript)",
       "semgrep",
       "sentinel-mirror",

--- a/.github/workflows/ci-cd-backend.yml
+++ b/.github/workflows/ci-cd-backend.yml
@@ -1118,13 +1118,22 @@ jobs:
             STATE_DIR="${HOME}/.museum-rollback/backend"
             mkdir -p "${STATE_DIR}"
 
-            # Tag whatever :latest currently is on this host as :previous BEFORE pulling.
-            # If :latest doesn't exist yet (first deploy), skip silently.
-            if docker image inspect "${IMAGE_REF}:latest" >/dev/null 2>&1; then
-              docker tag "${IMAGE_REF}:latest" "${IMAGE_REF}:previous"
-              echo "[pre-deploy] tagged ${IMAGE_REF}:latest → :previous"
+            # Capture the rollback TARGET = the IMAGE_TAG currently deployed.
+            # The prod compose pins `image: ...museum-backend:${IMAGE_TAG}` from
+            # /srv/museum/.env (SHA-pinned, NEVER :latest — see the 2026-05-13
+            # crash-loop note in the deploy step). So the rollback target is the
+            # specific SHA in .env right now, captured BEFORE the deploy step
+            # overwrites it. The old :latest→:previous retag scheme never worked
+            # under SHA-pinning (:latest is never present locally), which is why
+            # auto-rollback FATAL-ed on 2026-06-05 — rollback.sh now restores this
+            # tag into .env instead. Defensive: must not trip `set -e`.
+            PREV_TAG="$(sudo grep -E '^IMAGE_TAG=' /srv/museum/.env 2>/dev/null | head -1 | cut -d= -f2- | tr -d '[:space:]' || true)"
+            if [ -n "${PREV_TAG}" ]; then
+              echo "${PREV_TAG}" > "${STATE_DIR}/previous-image-tag.txt"
+              echo "[pre-deploy] captured rollback target IMAGE_TAG=${PREV_TAG}"
             else
-              echo "[pre-deploy] no existing :latest on host — first deploy, skipping :previous tag"
+              rm -f "${STATE_DIR}/previous-image-tag.txt"
+              echo "[pre-deploy] WARN — no IMAGE_TAG in /srv/museum/.env; rollback target unavailable (first deploy?)"
             fi
 
             # Capture pre-run migration count for the rollback delta.

--- a/museum-backend/deploy/rollback.sh
+++ b/museum-backend/deploy/rollback.sh
@@ -6,14 +6,16 @@
 # failing deploy. Called with:
 #   rollback.sh <compose-file> <service-name> <image-ref>
 #
-# State directory /srv/museum/.rollback/<service> holds:
-#   - applied-count.txt      # number of migrations newly applied by this deploy
-#   - previous-image.txt     # fully-qualified image ref tagged :previous before pull
+# State directory ${HOME}/.museum-rollback/<service> holds:
+#   - pre-count.txt              # migration count captured before this deploy
+#   - applied-count.txt          # number of migrations newly applied by this deploy
+#   - previous-image-tag.txt     # IMAGE_TAG (commit SHA) live before this deploy —
+#                                # the SHA-pinned rollback target restored into .env
 #
 # Exit codes:
 #   0  rollback succeeded
 #   42 migration revert failed
-#   43 image retag / restart failed
+#   43 image-tag restore / restart failed
 #   44 post-rollback healthcheck failed
 #
 set -u
@@ -87,16 +89,33 @@ else
   echo "[rollback] no new migrations to revert (code-only rollback)"
 fi
 
-# ─── 2. Retag :previous → :latest and restart the service ──────────────────
-echo "[rollback] retagging ${IMAGE_REF}:previous → ${IMAGE_REF}:latest"
-docker tag "${IMAGE_REF}:previous" "${IMAGE_REF}:latest"
-rc=$?
-if [ "${rc}" -ne 0 ]; then
-  echo "[rollback] FATAL — could not retag :previous (image missing?)"
+# ─── 2. Restore the previous IMAGE_TAG and restart the service ─────────────
+# SHA-pinned scheme: the prod compose references ...museum-backend:${IMAGE_TAG}
+# from /srv/museum/.env (NEVER :latest). The pre-deploy step captured the tag
+# that was live before this deploy into previous-image-tag.txt. Restore it into
+# .env and recreate the container so it boots the previous SHA. (The old
+# :previous→:latest retag never worked under SHA-pinning — it FATAL-ed on
+# 2026-06-05 because :latest is never present locally.)
+ENV_FILE=/srv/museum/.env
+PREV_TAG_FILE="${STATE_DIR}/previous-image-tag.txt"
+PREV_TAG=""
+if [ -f "${PREV_TAG_FILE}" ]; then
+  PREV_TAG="$(cat "${PREV_TAG_FILE}" | tr -d '[:space:]')"
+fi
+if [ -z "${PREV_TAG}" ]; then
+  echo "[rollback] FATAL — no previous IMAGE_TAG captured (previous-image-tag.txt missing/empty); cannot roll code back"
   exit 43
 fi
 
-echo "[rollback] recreating ${SERVICE}"
+echo "[rollback] restoring IMAGE_TAG=${PREV_TAG} in ${ENV_FILE}"
+if sudo grep -qE '^IMAGE_TAG=' "${ENV_FILE}" 2>/dev/null; then
+  sudo sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${PREV_TAG}/" "${ENV_FILE}"
+else
+  echo "IMAGE_TAG=${PREV_TAG}" | sudo tee -a "${ENV_FILE}" >/dev/null
+fi
+
+echo "[rollback] recreating ${SERVICE} on ${PREV_TAG}"
+export IMAGE_TAG="${PREV_TAG}"
 docker compose -f "${COMPOSE_FILE}" up -d --force-recreate --no-deps --timeout 30 "${SERVICE}"
 rc=$?
 if [ "${rc}" -ne 0 ]; then

--- a/museum-backend/scripts/smoke-api.cjs
+++ b/museum-backend/scripts/smoke-api.cjs
@@ -389,7 +389,18 @@ async function main() {
   //
   // Audio scope also pre-granted in case TTS adds its own gate in V1.x —
   // cheap belt-and-suspenders, no downside if unused.
-  for (const scope of ['third_party_ai_text_openai', 'third_party_ai_audio_openai']) {
+  //
+  // Image scope (`third_party_ai_image_openai`) is REQUIRED before POST
+  // /api/chat/compare: the visual-similarity endpoint sends the photo to the
+  // third-party image AI (provider-resolver.ts:69), and consent-gate enforcement
+  // returns 403 `consent_required` without it. Added 2026-06-05 after the prod
+  // smoke failed on compare (scope was introduced with the GDPR consent work
+  // 71f103b3/b2a2c53d but the smoke was never updated to mirror the user flow).
+  for (const scope of [
+    'third_party_ai_text_openai',
+    'third_party_ai_audio_openai',
+    'third_party_ai_image_openai',
+  ]) {
     await fetchJson({
       baseUrl,
       path: '/api/auth/consent',
@@ -400,7 +411,7 @@ async function main() {
       expected: 201,
     });
   }
-  console.log('[smoke:api] consent grants OK (text + audio)');
+  console.log('[smoke:api] consent grants OK (text + audio + image)');
 
   const created = await fetchJson({
     baseUrl,


### PR DESCRIPTION
## Objet
Corrige l'échec **deploy-prod** post-merge de #310 + applique le swap gouvernance des required checks.

## Contenu
- **fix(smoke)** `a0931911` — le post-deploy smoke prod n'accordait pas le consent `third_party_ai_image_openai` → `POST /api/chat/compare` 403 `consent_required` → deploy `failure`. Le smoke accorde désormais aussi le scope image (miroir du flux user réel).
- **fix(deploy)** `1fd9755e` — auto-rollback FATAL « No such image :previous » : le schéma `:previous`/`:latest` est incompatible avec le compose prod SHA-pinned (`image:...:${IMAGE_TAG}`). Réaligné : capture + restore de `IMAGE_TAG` dans `.env`. **Non testable en local** ; ne s'exécute que sur smoke-fail.
- **ci(governance)** `7ce4e6ae` — `ai-tests` (advisory-by-design, continue-on-error) sort des required checks ; `guardrail-failclosed` (hard gate déterministe ADR-047, ~40s) entre. Manifeste `branch-protection/main.json` ; reconcile applique au push main.

## Validation
- Pre-push 32 gates verts (zéro bypass). prod tourne déjà le nouveau code de #310 (deploy zero-downtime OK) ; ce cycle rend le smoke vert + répare le filet rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)