### PR TITLE
fix(test): recall@5 CI hook-timeout + teardown guard

### DIFF
--- a/museum-backend/tests/integration/chat/visual-similarity/recall.test.ts
+++ b/museum-backend/tests/integration/chat/visual-similarity/recall.test.ts
@@ -134,6 +134,12 @@ const cosine = (a: Float32Array, b: Float32Array): number => {
 };
 
 describeFn('recall@5 (T7.4 — crop-robustness, real ONNX model + pgvector)', () => {
+  // The beforeAll boots a Postgres testcontainer + runs migrations + builds the
+  // ONNX encoder; on a cold CI runner that exceeds Jest's default 5s hook
+  // timeout (which fails the hook AND leaves `encoder` undefined → the afterAll
+  // shutdown crashes). Match the sibling integration suites' generous budget.
+  jest.setTimeout(180_000);
+
   let harness: Awaited<ReturnType<typeof createIntegrationHarness>>;
   let repo: ArtworkEmbeddingRepository;
   let encoder: EmbeddingsPort;
@@ -167,8 +173,10 @@ describeFn('recall@5 (T7.4 — crop-robustness, real ONNX model + pgvector)', ()
 
   afterAll(async () => {
     // Release the native ONNX session so the worker doesn't hang (CLAUDE.md
-    // Stryker/open-handle gotcha). Optional + idempotent + fail-open.
-    await encoder.shutdown?.();
+    // Stryker/open-handle gotcha). Optional + idempotent + fail-open. Guard
+    // `encoder` itself: if beforeAll failed/timed out it is undefined, and an
+    // unguarded `encoder.shutdown` would throw a second, masking error.
+    await encoder?.shutdown?.();
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
Follow-up à la PR #315. La lane `recall-e2e.yml` a échoué sur push-to-main : le `describe` du test recall@5 n'avait pas de `jest.setTimeout()`, donc sur un runner CI froid le `beforeAll` (boot testcontainer Postgres + migrations + build encodeur ONNX, ~6,6s même en local) dépassait le timeout Jest par défaut de 5000ms — laissant `encoder` undefined, d'où un second `TypeError` masquant dans le `afterAll` (`encoder.shutdown?.()`).

Fix : `jest.setTimeout(180_000)` sur le describe (comme les suites integration sœurs) + garde `encoder?.shutdown?.()`. Vérifié localement : vert à recall@5 ≥ 0.85 (6,6s). Le fetch-modèle + Docker pgvector de la lane marchaient déjà en CI (le test atteignait `createIntegrationHarness`) — seuls le budget hook + la garde teardown manquaient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)