### PR TITLE
fix(smoke): bound-retry transient failures in the deploy smoke (cold-start resilience)

### DIFF
--- a/museum-backend/scripts/smoke-api.cjs
+++ b/museum-backend/scripts/smoke-api.cjs
@@ -35,6 +35,29 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Cold-start resilience (post-deploy): a freshly-recreated backend has a brief
+// window where connection pools / the OpenAI client / BullMQ workers are still
+// warming, so a single functional call can hit a TRANSIENT 5xx, a gateway HTML
+// page, or a network blip (observed post-deploy: TTS `fetch failed`, DELETE
+// non-JSON `<html>`, POST 500). The health probe already retries 24×; the
+// functional checks did not. We bound-retry ONLY transient classes so a single
+// blip does not roll back a good deploy — a PERSISTENT failure (real bug) still
+// fails after exhausting the attempts (fail-loud preserved). NOT retried: 4xx,
+// redirects, or wrong-value assertions.
+const SMOKE_TRANSIENT_RETRIES = Math.max(1, Number(getEnv('SMOKE_TRANSIENT_RETRIES', '3')) || 3);
+const SMOKE_TRANSIENT_RETRY_DELAY_MS =
+  Math.max(0, Number(getEnv('SMOKE_TRANSIENT_RETRY_DELAY_MS', '2500')) || 2500);
+
+/** True for network-level fetch failures + abort/timeout — always transient. */
+function isNetworkError(err) {
+  if (!err) return false;
+  if (err.name === 'AbortError') return true; // request timed out (controller.abort)
+  const m = `${err.message || ''} ${err.cause && err.cause.message ? err.cause.message : ''}`;
+  return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up|network|terminated|other side closed/i.test(
+    m,
+  );
+}
+
 function buildUrl(baseUrl, path) {
   return new URL(path, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`).toString();
 }
@@ -122,7 +145,7 @@ async function fetchMultipart({ baseUrl, path, token, fields, timeoutMs = DEFAUL
  *
  * R5 (C7.1) — see docs/roadmap-night/specs/R5.md §3.6 (D5).
  */
-async function fetchBinary({ baseUrl, path, method = 'POST', token, body, timeoutMs = DEFAULT_TIMEOUT_MS, expected }) {
+async function fetchBinaryOnce({ baseUrl, path, method = 'POST', token, body, timeoutMs = DEFAULT_TIMEOUT_MS, expected }) {
   const url = buildUrl(baseUrl, path);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -183,7 +206,7 @@ async function fetchBinary({ baseUrl, path, method = 'POST', token, body, timeou
   }
 }
 
-async function fetchJson({ baseUrl, path, method = 'GET', token, body, timeoutMs = DEFAULT_TIMEOUT_MS, expected }) {
+async function fetchJsonOnce({ baseUrl, path, method = 'GET', token, body, timeoutMs = DEFAULT_TIMEOUT_MS, expected }) {
   const url = buildUrl(baseUrl, path);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -220,21 +243,99 @@ async function fetchJson({ baseUrl, path, method = 'GET', token, body, timeoutMs
       try {
         json = JSON.parse(text);
       } catch (error) {
-        throw new Error(`Non-JSON response from ${method} ${path}: ${text.slice(0, 300)}`);
+        // A gateway/proxy HTML page (e.g. nginx 502/504) during the cold-start
+        // window — transient, retry-eligible.
+        const e = new Error(`Non-JSON response from ${method} ${path}: ${text.slice(0, 300)}`);
+        e.transient = true;
+        throw e;
       }
     }
 
     const expectedCodes = Array.isArray(expected) ? expected : [expected];
     if (!expectedCodes.includes(response.status)) {
-      throw new Error(
+      const e = new Error(
         `Unexpected status for ${method} ${path}: ${response.status}. Body: ${text.slice(0, 500) || '<empty>'}`,
       );
+      // Only 5xx is transient; an unexpected 4xx is a real client-contract error.
+      if (response.status >= 500) e.transient = true;
+      throw e;
     }
 
     return { status: response.status, json };
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Bound-retry wrapper around {@link fetchJsonOnce}. Retries ONLY transient
+ * failures (`err.transient` — set on a 5xx unexpected status or a non-JSON
+ * gateway page — or a network/abort error). A 4xx, a redirect, or a wrong-value
+ * assertion is NOT retried and fails immediately. A persistent transient still
+ * fails after `SMOKE_TRANSIENT_RETRIES` attempts, so fail-loud is preserved.
+ */
+async function fetchJson(opts) {
+  const retries = opts.retries ?? SMOKE_TRANSIENT_RETRIES;
+  let lastErr;
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      return await fetchJsonOnce(opts);
+    } catch (err) {
+      lastErr = err;
+      const transient = err.transient === true || isNetworkError(err);
+      if (transient && attempt < retries) {
+        console.log(
+          `[smoke:api] transient on ${opts.method || 'GET'} ${opts.path} ` +
+            `(attempt ${attempt}/${retries}): ${String(err.message).slice(0, 140)} — ` +
+            `retrying in ${SMOKE_TRANSIENT_RETRY_DELAY_MS}ms`,
+        );
+        await sleep(SMOKE_TRANSIENT_RETRY_DELAY_MS);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Bound-retry wrapper around {@link fetchBinaryOnce}. Unlike fetchJson, the
+ * binary helper RETURNS on an unexpected status (the caller asserts), so we
+ * retry when the returned status is an unexpected 5xx, or on a network error.
+ */
+async function fetchBinary(opts) {
+  const retries = opts.retries ?? SMOKE_TRANSIENT_RETRIES;
+  const expectedCodes = Array.isArray(opts.expected) ? opts.expected : [opts.expected];
+  let lastResult;
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      const result = await fetchBinaryOnce(opts);
+      lastResult = result;
+      const transient = !expectedCodes.includes(result.status) && result.status >= 500;
+      if (transient && attempt < retries) {
+        console.log(
+          `[smoke:api] transient binary on ${opts.method || 'POST'} ${opts.path} ` +
+            `(attempt ${attempt}/${retries}): status ${result.status} — ` +
+            `retrying in ${SMOKE_TRANSIENT_RETRY_DELAY_MS}ms`,
+        );
+        await sleep(SMOKE_TRANSIENT_RETRY_DELAY_MS);
+        continue;
+      }
+      return result;
+    } catch (err) {
+      if (isNetworkError(err) && attempt < retries) {
+        console.log(
+          `[smoke:api] transient binary network on ${opts.method || 'POST'} ${opts.path} ` +
+            `(attempt ${attempt}/${retries}): ${String(err.message).slice(0, 140)} — ` +
+            `retrying in ${SMOKE_TRANSIENT_RETRY_DELAY_MS}ms`,
+        );
+        await sleep(SMOKE_TRANSIENT_RETRY_DELAY_MS);
+        continue;
+      }
+      throw err;
+    }
+  }
+  return lastResult;
 }
 
 async function waitForHealthyApi({ baseUrl, timeoutMs, retries, retryDelayMs }) {

--- a/museum-backend/tests/integration/chat/visual-similarity/recall.test.ts
+++ b/museum-backend/tests/integration/chat/visual-similarity/recall.test.ts
@@ -134,6 +134,12 @@ const cosine = (a: Float32Array, b: Float32Array): number => {
 };
 
 describeFn('recall@5 (T7.4 — crop-robustness, real ONNX model + pgvector)', () => {
+  // The beforeAll boots a Postgres testcontainer + runs migrations + builds the
+  // ONNX encoder; on a cold CI runner that exceeds Jest's default 5s hook
+  // timeout (which fails the hook AND leaves `encoder` undefined → the afterAll
+  // shutdown crashes). Match the sibling integration suites' generous budget.
+  jest.setTimeout(180_000);
+
   let harness: Awaited<ReturnType<typeof createIntegrationHarness>>;
   let repo: ArtworkEmbeddingRepository;
   let encoder: EmbeddingsPort;
@@ -167,8 +173,10 @@ describeFn('recall@5 (T7.4 — crop-robustness, real ONNX model + pgvector)', ()
 
   afterAll(async () => {
     // Release the native ONNX session so the worker doesn't hang (CLAUDE.md
-    // Stryker/open-handle gotcha). Optional + idempotent + fail-open.
-    await encoder.shutdown?.();
+    // Stryker/open-handle gotcha). Optional + idempotent + fail-open. Guard
+    // `encoder` itself: if beforeAll failed/timed out it is undefined, and an
+    // unguarded `encoder.shutdown` would throw a second, masking error.
+    await encoder?.shutdown?.();
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
Suite à la remédiation #315/#317. `deploy-prod` a rollback 3× en post-merge sur **3 transients prod DIFFÉRENTS** (TTS `fetch failed`→OpenAI, DELETE non-JSON `<html>` gateway, POST /messages 500) — la signature de la fenêtre cold-start post-déploiement (pools / client OpenAI / workers BullMQ qui chauffent), **pas un bug** (un re-run propre est passé). Le health-probe retry déjà 24× ; les checks fonctionnels n'avaient aucun retry → un seul blip faisait un faux-rollback d'un deploy sain.

`fetchJson`/`fetchBinary` bound-retry désormais UNIQUEMENT les classes transitoires (5xx inattendu, page non-JSON gateway, erreur réseau/abort) jusqu'à `SMOKE_TRANSIENT_RETRIES` (défaut 3, 2,5s). NON retry : 4xx, redirects, assertions de valeur fausse. Un transient PERSISTANT échoue toujours après les tentatives → **fail-loud préservé** (un encodeur/TTS/endpoint vraiment mort rollback toujours).

Prouvé (sim throwaway) : transient-then-ok retourne au retry ; persistent-transient throw après 3 ; 4xx throw à la tentative 1 (no retry) ; network-error retry. Vérifié : `node --check` OK ; `smoke-api-tts-contract` 42/42 ; eslint clean.

Choisi par Tim (option « retry borné sur le smoke »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)