### PR TITLE
chore: post-merge follow-ups (Trivy timeout + Redis runbook no-staging)

### DIFF
--- a/.github/workflows/ci-cd-llm-guard.yml
+++ b/.github/workflows/ci-cd-llm-guard.yml
@@ -50,6 +50,9 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           trivyignores: museum-backend/ops/llm-guard-sidecar/.trivyignore
+          # Sidecar image is ~3GB (baked model weights); the 5m default scan
+          # deadline is borderline and flakes ("context deadline exceeded").
+          timeout: '15m'
 
       - name: Smoke test /health endpoint
         run: |

--- a/docs/RUNBOOKS/redis-rotation.md
+++ b/docs/RUNBOOKS/redis-rotation.md
@@ -12,7 +12,7 @@
 
 ## Pre-flight
 
-1. Confirm staging Redis instance is reachable and you can SSH to the prod VPS.
+1. Confirm you can SSH to the prod VPS. **V1 has no staging environment** (prod = stage until B2B revenue), so there is no staging Redis to rehearse against.
 2. Confirm `REDIS_PASSWORD` is the **only** secret on this rotation (do not bundle with other rotations — easier to revert).
 3. Generate the new password locally:
 
@@ -39,26 +39,27 @@ Update both:
 
 The VPS `.env` is the source of truth at runtime; GitHub secret is the source of truth for re-deploys.
 
-### 3. Apply on staging first
+### 3. Apply on prod
+
+> **No staging rehearsal in V1** (prod = stage until B2B revenue). Apply directly
+> to prod during an off-peak window (UTC 02:00–05:00 typical) with the rollback
+> (§Rollback) staged and ready. Re-introduce a staging-first rehearsal step here
+> once a staging environment exists.
 
 ```bash
-ssh deploy@staging.musaium.com
+ssh deploy@prod.musaium.com
 cd /srv/museum
 sed -i.bak "s/^REDIS_PASSWORD=.*/REDIS_PASSWORD=${NEW_PW}/" .env
-docker compose -f docker-compose.prod.yml up -d --force-recreate redis backend-staging
+docker compose -f docker-compose.prod.yml up -d --force-recreate redis backend
 ```
 
-Watch the backend logs for `[redis] connected` for ~60 s. If you see `NOAUTH Authentication required` or `WRONGPASS`, the env was not picked up — fall back via `git checkout -- .env.bak`.
+Watch the backend logs for `[redis] connected` for ~60 s. If you see `NOAUTH Authentication required` or `WRONGPASS`, the env was not picked up — fall back via `mv .env.bak .env` then re-recreate.
 
-### 4. Validate staging
+### 4. Validate prod
 
 - Hit `/api/health` — expect `database: 'up'`
 - Make a test login → ensure session creation works (uses Redis rate-limit bucket)
-- Watch Sentry for spikes in `RedisError` over the next 10 min
-
-### 5. Apply on prod
-
-Same steps as staging, on `prod.musaium.com`. Do this during an off-peak window (UTC 02:00–05:00 typical).
+- Watch Sentry for spikes in `RedisError` over the next 30 min (no staging soak, so watch longer than a rehearsed rotation would need)
 
 ### 6. Verify and close
 

--- a/museum-backend/ops/llm-guard-sidecar/README.md
+++ b/museum-backend/ops/llm-guard-sidecar/README.md
@@ -76,3 +76,15 @@ Response shape (both endpoints):
 ```
 
 The Node adapter (`llm-guard.adapter.ts`) maps `reason` substrings to the finite `AdvancedGuardrailBlockReason` union via a lookup table — any unknown reason collapses to `prompt_injection` (safest default). `error` is reserved for fail-CLOSED cases (network, timeout, HTTP ≥ 400, malformed JSON).
+
+## Security / supply-chain notes
+
+- **Trivy scan**: the CI `build` job scans this image (CRITICAL,HIGH). Accepted
+  CVEs live in `.trivyignore`, each with a runtime-impact rationale. The image is
+  ~3GB (baked model weights), so the scan runs with a raised 15m timeout
+  (`ci-cd-llm-guard.yml`) — the 5m default flakes with "context deadline exceeded".
+- **CVE-2026-4372** (transformers 4.51.3 RCE, fixed 5.3.0) is an accepted risk:
+  the RCE needs an attacker-controlled model, but this sidecar loads only its own
+  pinned protectai models and never takes a model path/id from a request. It is
+  upstream-blocked — `llm-guard` 0.3.16 hard-pins `transformers==4.51.3`. Drop the
+  ignore once `llm-guard` supports transformers ≥ 5.3.0.


### PR DESCRIPTION
Small follow-ups surfaced while auditing/merging the open PRs.

## 1. `ci(llm-guard)`: raise Trivy scan timeout to 15m
The sidecar image bakes ~3GB of model weights; Trivy's default 5m scan deadline is borderline and intermittently fails with `context deadline exceeded` (observed passing on one commit, timing out on the next — same image). Trivy itself WARNs to raise it. Not a vulnerability — `.trivyignore` already covers the accepted CVEs. This is a hardening fix that was orphaned when #287 auto-merged (Renovate automerge fired at the pre-fix commit).

## 2. `docs(llm-guard)`: document the accepted CVE + timeout
README note next to the code it governs, so future maintainers see why CVE-2026-4372 is accepted and where the timeout lives.

## 3. `docs(runbook)`: redis-rotation reflects no-staging V1 — resolves stale steps flagged by #321
The rotation runbook assumed a staging environment (`ssh staging.musaium.com`, `backend-staging`, "apply on staging first") — none of which exists in V1: no `backend-staging` in `docker-compose.prod.yml`, `deploy-staging` commented out in `ci-cd-backend.yml`, no `staging` branch. Rewrote §3–5 to a single prod apply with a no-rehearsal caution + longer soak. The rotation itself (issue #321) remains an ops action for the maintainer.

Pure CI/docs — no application code.